### PR TITLE
#62 Return newly created object from insert actions

### DIFF
--- a/docs/store/inserting-and-updating-data.md
+++ b/docs/store/inserting-and-updating-data.md
@@ -99,7 +99,7 @@ store.dispatch('entities/users/insert', {
 })
 ```
 
-## Default Values
+### Default Values
 
 If you pass an object that has missing fields defined in the model, that field will be automatically generated with the default value defined in the model.
 
@@ -136,6 +136,52 @@ store.dispatch('entities/users/create', {
     }
   }
 }
+```
+
+### Get Newly Inserted Data
+
+Both `create` and `insert` will return the created data as Promise so that you can get them as a return value.
+
+```js
+store.dispatch('entities/users/create', {
+  data: { id: 1, name: 'John Doe' }
+}).then((user) => {
+  console.log(user)
+})
+
+// User { id: 1, name: 'John Doe' }
+```
+
+If you insert an array of data, the returned object is going to be an array of data.
+
+```js
+store.dispatch('entities/users/create', {
+  data: [
+    { id: 1, name: 'John Doe' },
+    { id: 2, name: 'Jane Doe' }
+  ]
+}).then((users) => {
+  console.log(users)
+})
+
+/*
+  [
+    User { id: 1, name: 'John Doe' },
+    User { id: 2, name: 'Jane Doe' }
+  ]
+*/
+```
+
+If you prefer to use [async / await](https://tc39.github.io/ecmascript-asyncawait), then you can compose inserts like this.
+
+```js
+const uset = await store.dispatch('entities/users/create', {
+  data: { id: 1, name: 'John Doe' }
+})
+
+console.log(user)
+
+// User { id: 1, name: 'John Doe' }
 ```
 
 ### Inserting Relationships

--- a/docs/store/inserting-and-updating-data.md
+++ b/docs/store/inserting-and-updating-data.md
@@ -175,7 +175,7 @@ store.dispatch('entities/users/create', {
 If you prefer to use [async / await](https://tc39.github.io/ecmascript-asyncawait), then you can compose inserts like this.
 
 ```js
-const uset = await store.dispatch('entities/users/create', {
+const user = await store.dispatch('entities/users/create', {
   data: { id: 1, name: 'John Doe' }
 })
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/revolver-app/vuex-orm.git"
+    "url": "git+https://github.com/vuex-orm/vuex-orm.git"
   },
   "keywords": [
     "vue",
@@ -35,7 +35,7 @@
   "author": "Kia Ishii",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/revolver-app/vuex-orm/issues"
+    "url": "https://github.com/vuex-orm/vuex-orm/issues"
   },
   "dependencies": {
     "@types/lodash-es": "^4.17.0",

--- a/src/modules/mutations.ts
+++ b/src/modules/mutations.ts
@@ -9,8 +9,10 @@ const mutations: Mutations = {
    * Save the given data to the state. This will replace any existing
    * data in the state.
    */
-  create (state, { entity, data, insert = [] }) {
-    Repo.create(state, entity, data, insert)
+  create (state, { entity, data, insert = [], done = null }) {
+    const result = Repo.create(state, entity, data, insert)
+
+    done && done(result)
   },
 
   /**
@@ -18,8 +20,10 @@ const mutations: Mutations = {
    * remove existing data within the state, but it will update the data
    * with the same primary key.
    */
-  insert (state, { entity, data, create = [] }) {
-    Repo.insert(state, entity, data, create)
+  insert (state, { entity, data, create = [], done = null }) {
+    const result = Repo.insert(state, entity, data, create)
+
+    done && done(result)
   },
 
   /**

--- a/src/modules/rootActions.ts
+++ b/src/modules/rootActions.ts
@@ -9,7 +9,9 @@ const rootActions: RootActions = {
    * data in the state.
    */
   create ({ commit }, { entity, data, insert = [] }) {
-    commit('create', { entity, data, insert })
+    return new Promise((resolve) => {
+      commit('create', { entity, data, insert, done: resolve })
+    })
   },
 
   /**
@@ -18,7 +20,9 @@ const rootActions: RootActions = {
    * with the same primary key.
    */
   insert ({ commit }, { entity, data, create = [] }) {
-    commit('insert', { entity, data, create })
+    return new Promise((resolve) => {
+      commit('insert', { entity, data, create, done: resolve })
+    })
   },
 
   /**

--- a/src/modules/subActions.ts
+++ b/src/modules/subActions.ts
@@ -8,8 +8,8 @@ const subActions: SubActions = {
    * Save the given data to the state. This will replace any existing
    * data in the state.
    */
-  create ({ commit, state }, { data, insert = [] }) {
-    commit(`${state.$connection}/create`, { entity: state.$name, data, insert }, { root: true })
+  async create ({ dispatch, state }, { data, insert = [] }) {
+    return dispatch(`${state.$connection}/create`, { entity: state.$name, data, insert }, { root: true })
   },
 
   /**
@@ -17,8 +17,8 @@ const subActions: SubActions = {
    * remove existing data within the state, but it will update the data
    * with the same primary key.
    */
-  insert ({ commit, state }, { data, create = [] }) {
-    commit(`${state.$connection}/insert`, { entity: state.$name, data, create }, { root: true })
+  async insert ({ dispatch, state }, { data, create = [] }) {
+    return dispatch(`${state.$connection}/insert`, { entity: state.$name, data, create }, { root: true })
   },
 
   /**

--- a/src/repo/relations/BelongsToMany.ts
+++ b/src/repo/relations/BelongsToMany.ts
@@ -104,9 +104,13 @@ export default class BelongsToMany extends Relation {
   /**
    * Make model instances of the relation.
    */
-  make (): Model[] | null {
+  make (): Model[] {
     if (this.records.length === 0) {
-      return null
+      return []
+    }
+
+    if (typeof this.records[0] !== 'object') {
+      return []
     }
 
     return this.records.map(record => new this.related(record))

--- a/src/repo/relations/BelongsToMany.ts
+++ b/src/repo/relations/BelongsToMany.ts
@@ -109,7 +109,7 @@ export default class BelongsToMany extends Relation {
       return []
     }
 
-    if (typeof this.records[0] !== 'object') {
+    if (typeof (this.records[0] as any) !== 'object') {
       return []
     }
 

--- a/src/repo/relations/HasMany.ts
+++ b/src/repo/relations/HasMany.ts
@@ -53,8 +53,12 @@ export default class HasMany extends Relation {
   /**
    * Make model instances of the relation.
    */
-  make (): Model[] | null {
+  make (): Model[] {
     if (this.records.length === 0) {
+      return []
+    }
+
+    if (typeof this.records[0] !== 'object') {
       return []
     }
 

--- a/src/repo/relations/HasMany.ts
+++ b/src/repo/relations/HasMany.ts
@@ -58,7 +58,7 @@ export default class HasMany extends Relation {
       return []
     }
 
-    if (typeof this.records[0] !== 'object') {
+    if (typeof (this.records[0] as any) !== 'object') {
       return []
     }
 

--- a/src/repo/relations/HasManyBy.ts
+++ b/src/repo/relations/HasManyBy.ts
@@ -60,6 +60,10 @@ export default class HasManyBy extends Relation {
       return []
     }
 
+    if (typeof this.records[0] !== 'object') {
+      return []
+    }
+
     return this.records.map(record => new this.parent(record))
   }
 }

--- a/src/repo/relations/HasManyBy.ts
+++ b/src/repo/relations/HasManyBy.ts
@@ -60,7 +60,7 @@ export default class HasManyBy extends Relation {
       return []
     }
 
-    if (typeof this.records[0] !== 'object') {
+    if (typeof (this.records[0] as any) !== 'object') {
       return []
     }
 

--- a/test/feature/RootModules.spec.js
+++ b/test/feature/RootModules.spec.js
@@ -12,36 +12,6 @@ const entities = [
 ]
 
 describe('Root modules', () => {
-  it('can create data by action', async () => {
-    const store = createStore(entities)
-
-    const data = {
-      id: 1,
-      user_id: 2,
-      user: { id: 2 }
-    }
-
-    await store.dispatch('entities/create', { entity: 'profiles', data })
-
-    expect(store.state.entities.profiles.data[1].id).toBe(1)
-    expect(store.state.entities.users.data[2].id).toBe(2)
-  })
-
-  it('can insert data by action', async () => {
-    const store = createStore(entities)
-
-    const data = {
-      id: 1,
-      user_id: 2,
-      user: { id: 2 }
-    }
-
-    await store.dispatch('entities/insert', { entity: 'profiles', data })
-
-    expect(store.state.entities.profiles.data[1].id).toBe(1)
-    expect(store.state.entities.users.data[2].id).toBe(2)
-  })
-
   it('can create a query by directly calling getter of the entity name', async () => {
     const store = createStore(entities)
 

--- a/test/feature/RootModules.spec.js
+++ b/test/feature/RootModules.spec.js
@@ -11,7 +11,7 @@ const entities = [
   { model: Comment }
 ]
 
-describe('Root modules', () => {
+describe('Root Modules', () => {
   it('can create a query by directly calling getter of the entity name', async () => {
     const store = createStore(entities)
 

--- a/test/feature/RootModules_Inserts.spec.js
+++ b/test/feature/RootModules_Inserts.spec.js
@@ -1,0 +1,180 @@
+import { createStore } from 'test/support/Helpers'
+import Model from 'app/Model'
+
+describe('Root Modules – Inserts', () => {
+  it('returns a newly created object when creating data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = { id: 1, name: 'John Doe' }
+
+    const user = await store.dispatch('entities/create', { entity: 'users', data })
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.name).toBe('John Doe')
+  })
+
+  it('returns many newly created object when creating multiple data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = [
+      { id: 1, name: 'John Doe' },
+      { id: 2, name: 'Jane Doe' },
+      { id: 3, name: 'Johnny Doe' }
+    ]
+
+    const users = await store.dispatch('entities/create', { entity: 'users', data })
+
+    expect(users.length).toBe(3)
+    expect(users[1]).toBeInstanceOf(User)
+    expect(users[2].name).toBe('Johnny Doe')
+  })
+
+  it('returns only the newly created root entity when creating data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          posts: this.hasMany(Post, 'user_id')
+        }
+      }
+    }
+
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          user_id: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }, { model: Post }])
+
+    const data = {
+      id: 1,
+      posts: [
+        { id: 2, user_id: 1 },
+        { id: 3, user_id: 1 }
+      ]
+    }
+
+    const user = await store.dispatch('entities/create', { entity: 'users', data })
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.posts).toEqual([])
+  })
+
+  it('returns a newly created object when inserting data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = { id: 1, name: 'John Doe' }
+
+    const user = await store.dispatch('entities/insert', { entity: 'users', data })
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.name).toBe('John Doe')
+  })
+
+  it('returns many newly created object when inserting multiple data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = [
+      { id: 1, name: 'John Doe' },
+      { id: 2, name: 'Jane Doe' },
+      { id: 3, name: 'Johnny Doe' }
+    ]
+
+    const users = await store.dispatch('entities/insert', { entity: 'users', data })
+
+    expect(users.length).toBe(3)
+    expect(users[1]).toBeInstanceOf(User)
+    expect(users[2].name).toBe('Johnny Doe')
+  })
+
+  it('returns only the newly created root entity when inserting data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          posts: this.hasMany(Post, 'user_id')
+        }
+      }
+    }
+
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          user_id: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }, { model: Post }])
+
+    const data = {
+      id: 1,
+      posts: [
+        { id: 2, user_id: 1 },
+        { id: 3, user_id: 1 }
+      ]
+    }
+
+    const user = await store.dispatch('entities/insert', { entity: 'users', data })
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.posts).toEqual([])
+  })
+})

--- a/test/feature/RootModules_Inserts.spec.js
+++ b/test/feature/RootModules_Inserts.spec.js
@@ -2,6 +2,31 @@ import { createStore } from 'test/support/Helpers'
 import Model from 'app/Model'
 
 describe('Root Modules – Inserts', () => {
+  it('can create data by action', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = {
+      id: 1,
+      name: 'John Doe'
+    }
+
+    await store.dispatch('entities/create', { entity: 'users', data })
+
+    expect(store.state.entities.users.data[1].id).toBe(1)
+    expect(store.state.entities.users.data[1].name).toBe('John Doe')
+  })
+
   it('returns a newly created object when creating data', async () => {
     class User extends Model {
       static entity = 'users'
@@ -88,6 +113,31 @@ describe('Root Modules – Inserts', () => {
 
     expect(user).toBeInstanceOf(User)
     expect(user.posts).toEqual([])
+  })
+
+  it('can insert data by action', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = {
+      id: 1,
+      name: 'John Doe'
+    }
+
+    await store.dispatch('entities/insert', { entity: 'users', data })
+
+    expect(store.state.entities.users.data[1].id).toBe(1)
+    expect(store.state.entities.users.data[1].name).toBe('John Doe')
   })
 
   it('returns a newly created object when inserting data', async () => {

--- a/test/feature/SubModules.spec.js
+++ b/test/feature/SubModules.spec.js
@@ -11,37 +11,7 @@ const entities = [
   { model: Comment }
 ]
 
-describe('Sub modules', () => {
-  it('can create data by action', async () => {
-    const store = createStore(entities)
-
-    const data = {
-      id: 1,
-      user_id: 2,
-      user: { id: 2 }
-    }
-
-    await store.dispatch('entities/profiles/create', { data })
-
-    expect(store.state.entities.profiles.data[1].id).toBe(1)
-    expect(store.state.entities.users.data[2].id).toBe(2)
-  })
-
-  it('can insert data by action', async () => {
-    const store = createStore(entities)
-
-    const data = {
-      id: 1,
-      user_id: 2,
-      user: { id: 2 }
-    }
-
-    await store.dispatch('entities/profiles/insert', { data })
-
-    expect(store.state.entities.profiles.data[1].id).toBe(1)
-    expect(store.state.entities.users.data[2].id).toBe(2)
-  })
-
+describe('Sub Modules', () => {
   it('can find a data by getter', async () => {
     const store = createStore(entities)
 

--- a/test/feature/SubModules_Inserts.spec.js
+++ b/test/feature/SubModules_Inserts.spec.js
@@ -1,0 +1,230 @@
+import { createStore } from 'test/support/Helpers'
+import Model from 'app/Model'
+
+describe('Sub Modules – Inserts', () => {
+  it('can create data by action', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = {
+      id: 1,
+      name: 'John Doe'
+    }
+
+    await store.dispatch('entities/users/create', { data })
+
+    expect(store.state.entities.users.data[1].id).toBe(1)
+    expect(store.state.entities.users.data[1].name).toBe('John Doe')
+  })
+
+  it('returns a newly created object when creating data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = { id: 1, name: 'John Doe' }
+
+    const user = await store.dispatch('entities/users/create', { data })
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.name).toBe('John Doe')
+  })
+
+  it('returns many newly created object when creating multiple data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = [
+      { id: 1, name: 'John Doe' },
+      { id: 2, name: 'Jane Doe' },
+      { id: 3, name: 'Johnny Doe' }
+    ]
+
+    const users = await store.dispatch('entities/users/create', { data })
+
+    expect(users.length).toBe(3)
+    expect(users[1]).toBeInstanceOf(User)
+    expect(users[2].name).toBe('Johnny Doe')
+  })
+
+  it('returns only the newly created root entity when creating data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          posts: this.hasMany(Post, 'user_id')
+        }
+      }
+    }
+
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          user_id: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }, { model: Post }])
+
+    const data = {
+      id: 1,
+      posts: [
+        { id: 2, user_id: 1 },
+        { id: 3, user_id: 1 }
+      ]
+    }
+
+    const user = await store.dispatch('entities/users/create', { data })
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.posts).toEqual([])
+  })
+
+  it('can insert data by action', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = {
+      id: 1,
+      name: 'John Doe'
+    }
+
+    await store.dispatch('entities/users/insert', { data })
+
+    expect(store.state.entities.users.data[1].id).toBe(1)
+    expect(store.state.entities.users.data[1].name).toBe('John Doe')
+  })
+
+  it('returns a newly created object when inserting data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = { id: 1, name: 'John Doe' }
+
+    const user = await store.dispatch('entities/users/insert', { data })
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.name).toBe('John Doe')
+  })
+
+  it('returns many newly created object when inserting multiple data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }])
+
+    const data = [
+      { id: 1, name: 'John Doe' },
+      { id: 2, name: 'Jane Doe' },
+      { id: 3, name: 'Johnny Doe' }
+    ]
+
+    const users = await store.dispatch('entities/users/insert', { data })
+
+    expect(users.length).toBe(3)
+    expect(users[1]).toBeInstanceOf(User)
+    expect(users[2].name).toBe('Johnny Doe')
+  })
+
+  it('returns only the newly created root entity when inserting data', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          posts: this.hasMany(Post, 'user_id')
+        }
+      }
+    }
+
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          user_id: this.attr('')
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }, { model: Post }])
+
+    const data = {
+      id: 1,
+      posts: [
+        { id: 2, user_id: 1 },
+        { id: 3, user_id: 1 }
+      ]
+    }
+
+    const user = await store.dispatch('entities/users/insert', { data })
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.posts).toEqual([])
+  })
+})


### PR DESCRIPTION
Issue #62 

This PR makes `create` and `insert` actions to return newly created objects. Doing kinda hacky solution here that passing Promise to the mutation and resolving inside mutation to get result back at action. Test is passing and it works. I think it wouldn't cause any problem...?

#### TODO

- [x] Add documentation.