### PR TITLE
with() syntax improvements

### DIFF
--- a/docs/relationships/retrieving-relationships.md
+++ b/docs/relationships/retrieving-relationships.md
@@ -68,6 +68,14 @@ const user = store.getters['entities/users/query']()
 */
 ```
 
+You can load multiple sub relations by separating them with `|`;
+
+```js
+const user = store.getters['entities/users/query']()
+  .with('posts.comments|reviews')
+  .find(1)
+```
+
 ## Load All Relations
 
 You can load all Relations with using the `withAll` method.
@@ -105,6 +113,14 @@ const user = store.getters['entities/users/query']()
     ]
   }
 */
+```
+
+To fetch all sub relations of a relation using the dot syntax, use `*`;
+
+```js
+const user = store.getters['entities/users/query']()
+  .with('posts.*') // Fetches all relations of all posts
+  .find(1)
 ```
 
 To fetch all sub relations to a certain level you can use the `withAllRecursive` method.

--- a/docs/relationships/retrieving-relationships.md
+++ b/docs/relationships/retrieving-relationships.md
@@ -68,6 +68,91 @@ const user = store.getters['entities/users/query']()
 */
 ```
 
+## Load All Relations
+
+You can load all Relations with using the `withAll` method.
+
+```js
+const user = store.getters['entities/users/query']()
+  .withAll()
+  .find(1)
+
+/*
+  User {
+    id: 1,
+    name: 'john',
+    profile: Profile {
+      id: 1,
+      user_id: 1,
+      age: 24
+    },
+    posts: [
+      Post: {
+        id: 1,
+        user_id: 1,
+        body: '...',
+
+        comments: null
+      },
+
+      Post: {
+        id: 2,
+        user_id: 1,
+        body: '...',
+
+        comments: null
+      },
+    ]
+  }
+*/
+```
+
+To fetch all sub relations to a certain level you can use the `withAllRecursive` method.
+You can specify a depth to which relations should be loaded. The depth defaults to 3, so
+if you call `withAllRecursive` with no arguments, it will fetch all sub relations of
+sub relations of sub relations of the queried entity.
+
+```js
+const user = store.getters['entities/users/query']()
+  .withAllRecursive()
+  .find(1)
+
+/*
+  User {
+    id: 1,
+    name: 'john',
+    profile: Profile {
+      id: 1,
+      user_id: 1,
+      age: 24
+    },
+    posts: [
+      Post: {
+        id: 1,
+        user_id: 1,
+        body: '...',
+
+        comments: [
+          Comment: { id: 1, post_id: 1, body: '...' },
+          Comment: { id: 2, post_id: 1, body: '...' }
+        ]
+      },
+
+      Post: {
+        id: 2,
+        user_id: 1,
+        body: '...',
+
+        comments: [
+          Comment: { id: 3, post_id: 2, body: '...' },
+          Comment: { id: 4, post_id: 2, body: '...' }
+        ]
+      },
+    ]
+  }
+*/
+```
+
 ## Relation Constraint
 
 To filter the result of relation loaded with `with` method, you can do so by passing a closure to the second argument.

--- a/src/attributes/relations/Relation.ts
+++ b/src/attributes/relations/Relation.ts
@@ -22,7 +22,17 @@ export default abstract class Relation extends Attribute {
     if (relations.length !== 1) {
       relations.shift()
 
-      query.with(relations.join('.'))
+      if (relations.length > 1) {
+        query.with(relations.join('.'))
+      } else {
+        if (relations[0] === '*') {
+          query.withAll()
+        } else {
+          for (const relation of relations[0].split('|')) {
+            query.with(relation)
+          }
+        }
+      }
 
       return
     }

--- a/src/repo/Repo.ts
+++ b/src/repo/Repo.ts
@@ -480,9 +480,13 @@ export default class Repo {
   }
 
   withAll (constraints: ConstraintCollection = {}): this {
-    for (const field in this.entity.fields()) {
-      const constraint = (field in constraints) ? constraints[field] : null;
-      this.load.push({ name: field, constraint })
+    const fields = this.entity.fields()
+
+    for (const field in fields) {
+      if (Attrs.isRelation(fields[field])) {
+        const constraint = (field in constraints) ? constraints[field] : null
+        this.load.push({ name: field, constraint })
+      }
     }
 
     return this

--- a/src/repo/Repo.ts
+++ b/src/repo/Repo.ts
@@ -11,9 +11,7 @@ export type Buildable = PlainItem | PlainCollection | null
 
 export type Constraint = (query: Repo) => void | boolean
 
-export type ConstraintCollection = {
-  [relationName: string]: Constraint
-}
+export type ConstraintCallback = (relationName: string) => Constraint | null
 
 export interface Relation {
   name: string
@@ -479,15 +477,30 @@ export default class Repo {
     return this
   }
 
-  withAll (constraints: ConstraintCollection = {}): this {
+  /**
+   * Query all relations.
+   */
+  withAll (constraints: ConstraintCallback = () => null): this {
     const fields = this.entity.fields()
 
     for (const field in fields) {
       if (Attrs.isRelation(fields[field])) {
-        const constraint = (field in constraints) ? constraints[field] : null
-        this.load.push({ name: field, constraint })
+        this.load.push({ name: field, constraint: constraints(field) })
       }
     }
+
+    return this
+  }
+
+  /**
+   * Query all relations recursively.
+   */
+  withAllRecursive (depth: number = 3): this {
+    this.withAll(() => {
+      return depth > 0 ? (query: Repo) => {
+        query.withAllRecursive(depth - 1)
+      } : null
+    })
 
     return this
   }

--- a/src/repo/Repo.ts
+++ b/src/repo/Repo.ts
@@ -472,7 +472,11 @@ export default class Repo {
    * Set the relationships that should be loaded.
    */
   with (name: string, constraint: Constraint | null = null): this {
-    this.load.push({ name, constraint })
+    if (name === '*') {
+      this.withAll()
+    } else {
+      this.load.push({ name, constraint })
+    }
 
     return this
   }

--- a/src/repo/Repo.ts
+++ b/src/repo/Repo.ts
@@ -11,6 +11,10 @@ export type Buildable = PlainItem | PlainCollection | null
 
 export type Constraint = (query: Repo) => void | boolean
 
+export type ConstraintCollection = {
+  [relationName: string]: Constraint
+}
+
 export interface Relation {
   name: string
   constraint: null | Constraint
@@ -471,6 +475,15 @@ export default class Repo {
    */
   with (name: string, constraint: Constraint | null = null): this {
     this.load.push({ name, constraint })
+
+    return this
+  }
+
+  withAll (constraints: ConstraintCollection = {}): this {
+    for (const field in this.entity.fields()) {
+      const constraint = (field in constraints) ? constraints[field] : null;
+      this.load.push({ name: field, constraint })
+    }
 
     return this
   }

--- a/test/unit/repo/repo/Repo_Retrieve_Relations.spec.js
+++ b/test/unit/repo/repo/Repo_Retrieve_Relations.spec.js
@@ -227,9 +227,74 @@ describe('Repo – Retrieve – Relations', () => {
     };
 
 
-    const post = Repo.query(state, 'users', false).withAll().first()
+    const user = Repo.query(state, 'users', false).withAll().first()
 
-    expect(post).toEqual(expected)
+    expect(user).toEqual(expected)
+  })
+
+  it('can query all relations recursively', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+          '1': { $id: 1, id: 1, profile: 3 }
+        }},
+      profiles: { data: {
+          '3': { $id: 3, id: 3, user_id: 1, users: 1 }
+        }},
+      posts: { data: {
+          '1': { id: 1, user_id: 1, title: 'Post Title', reviews: [1, 2] }
+        }},
+      comments: { data: {
+          '1': { id: 1, post_id: 1, type: 'review' }
+        }},
+      likes: { data: {
+          '1': { id: 1, comment_id: 1 }
+        }},
+      reviews: { data: {
+          '1': { id: 1 },
+          '2': { id: 2 }
+        }}
+    }
+
+    const expected = {
+      '$id': 1,
+      'id': 1,
+      'posts': [{
+        'author': {
+          '$id': 1,
+          'id': 1,
+          'posts': [{'id': 1, 'reviews': [1, 2], 'title': 'Post Title', 'user_id': 1}],
+          'profile': {'$id': 3, 'id': 3, 'user_id': 1, 'users': 1}
+        },
+        'comments': [{
+          'id': 1,
+          'likes': [{'comment_id': 1, 'id': 1}],
+          'post': {'id': 1, 'reviews': [1, 2], 'title': 'Post Title', 'user_id': 1},
+          'post_id': 1,
+          'type': 'review'
+        }],
+        'id': 1,
+        'reviews': [{'id': 1}, {'id': 2}],
+        'title': 'Post Title',
+        'user_id': 1
+      }],
+      'profile': {
+        '$id': 3,
+        'id': 3,
+        'user': {
+          '$id': 1,
+          'id': 1,
+          'posts': [{'id': 1, 'reviews': [1, 2], 'title': 'Post Title', 'user_id': 1}],
+          'profile': {'$id': 3, 'id': 3, 'user_id': 1, 'users': 1}
+        },
+        'user_id': 1,
+        'users': 1
+      }
+    };
+
+    const user = Repo.query(state, 'users', false).withAllRecursive(2).first()
+
+    expect(user).toEqual(expected)
   })
 
   it('can resolve nested relation', () => {

--- a/test/unit/repo/repo/Repo_Retrieve_Relations.spec.js
+++ b/test/unit/repo/repo/Repo_Retrieve_Relations.spec.js
@@ -180,13 +180,13 @@ describe('Repo – Retrieve – Relations', () => {
     const state = {
       name: 'entities',
       posts: { data: {
-        '1': { id: 1, title: 'Post Title', comments: [1, 2, 3] }
-      }},
+          '1': { id: 1, title: 'Post Title', comments: [1, 2, 3] }
+        }},
       comments: { data: {
-        '1': { id: 1, post_id: 1, type: 'review' },
-        '2': { id: 2, post_id: 1, type: 'comment' },
-        '3': { id: 3, post_id: 1, type: 'review' }
-      }}
+          '1': { id: 1, post_id: 1, type: 'review' },
+          '2': { id: 2, post_id: 1, type: 'comment' },
+          '3': { id: 3, post_id: 1, type: 'review' }
+        }}
     }
 
     const expected = {
@@ -201,6 +201,33 @@ describe('Repo – Retrieve – Relations', () => {
     const post = Repo.query(state, 'posts', false).with('comments', (query) => {
       query.where('type', 'review')
     }).first()
+
+    expect(post).toEqual(expected)
+  })
+
+  it('can query all relations', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+          '1': { $id: 1, id: 1, profile: 3 }
+        }},
+      profiles: { data: {
+          '3': { $id: 3, id: 3, user_id: 1, users: 1 }
+        }},
+      posts: { data: {
+          '3': { $id: 3, id: 3, user_id: 1, author: 1 }
+        }}
+    }
+
+    const expected = {
+      $id: 1,
+      id: 1,
+      profile: { $id: 3, id: 3, user_id: 1, users: 1 },
+      posts: [{ $id: 3, id: 3, user_id: 1, author: 1 }]
+    };
+
+
+    const post = Repo.query(state, 'users', false).withAll().first()
 
     expect(post).toEqual(expected)
   })


### PR DESCRIPTION
This PR depends on https://github.com/vuex-orm/vuex-orm/pull/106.

This PR adds with() syntax improvements:
- You can now write `with('posts.comments|reviews')` to fetch multiple sub relations
- You can now write `with('posts.*')` to fetch all sub relations of a relation
- You can now write `with('*')` as an alias for `withAll()` for consistency purposes