### PR TITLE
#113 Improve performance when loading many relationships

### DIFF
--- a/docs/relationships/retrieving-relationships.md
+++ b/docs/relationships/retrieving-relationships.md
@@ -251,7 +251,7 @@ You may also specify count as well.
 store.getters['entities/posts/query']().has('comments', 2).get()
 ```
 
-Also, you may add an operator to customize your query even more. The supported operators are `>`, `>=`, `<` and `<=`.
+Also, you may add an operator to customize your query even more. The supported operators are `=`, `>`, `>=`, `<` and `<=`.
 
 ```js
 // Retrieve all posts that have more than 2 comments.
@@ -261,30 +261,25 @@ store.getters['entities/posts/query']().has('comments', '>' 2).get()
 store.getters['entities/posts/query']().has('comments', '<=' 2).get()
 ```
 
-And even more, you can pass closure for a complex query. If closure may return boolean, or it can just add constraints to the query.
+If you need even more power, you may use the `whereHas` method to put "where" conditions on your `has` queries. This method allow you to add customized constraints to a relationship constraint, such as checking the content of a comment.
 
 ```js
-// Retrieve all posts that have user_id of 1.
-store.getters['entities/posts/query']().has('comments', (query) => {
+// Retrieve all posts that have comment from user_id 1.
+store.getters['entities/posts/query']().whereHas('comments', (query) => {
   query.where('user_id', 1)
-}).get()
-
-// Retrieve all posts that have more than 2 comments with user_id of 1.
-store.getters['entities/posts/query']().has('comments', (query) => {
-  return query.where('user_id', 1).count() > 2
 }).get()
 ```
 
 ## Querying Relationship Absence
 
-To retrieve records depending on absence of the relationship, use `hasNot` method. `hasNot` method will work same as `has` but in opposite result.
+To retrieve records depending on absence of the relationship, use `hasNot` and `whereHasNot` method. These method will work same as `has` and `whereHas` but in opposite result.
 
 ```js
 // Retrieve all posts that doesn't have comments.
 store.getters['entities/posts/query']().hasNot('comments').get()
 
 // Retrieve all posts that doesn't have comment with user_id of 1.
-store.getters['entities/posts/query']().hasNot('comments', (query) => {
+store.getters['entities/posts/query']().whereHasNot('comments', (query) => {
   query.where('user_id', 1)
 }).get()
 ```

--- a/src/attributes/relations/BelongsTo.ts
+++ b/src/attributes/relations/BelongsTo.ts
@@ -1,4 +1,4 @@
-import { Record, NormalizedData, PlainItem } from '../../data/Contract'
+import { Record, NormalizedData, PlainCollection } from '../../data/Contract'
 import Model from '../../model/Model'
 import Repo, { Relation as Load } from '../../repo/Repo'
 import Relation from './Relation'
@@ -81,13 +81,19 @@ export default class BelongsTo extends Relation {
   /**
    * Load the belongs to relationship for the record.
    */
-  load (repo: Repo, record: Record, relation: Load): PlainItem {
-    const query = new Repo(repo.state, this.parent.entity, false)
+  load (repo: Repo, collection: PlainCollection, relation: Load): PlainCollection {
+    const relatedPath = this.relatedPath(relation.name)
 
-    query.where(this.ownerKey, record[this.foreignKey])
+    const relatedQuery = new Repo(repo.state, this.parent.entity, false)
 
-    this.addConstraint(query, relation)
+    this.addConstraint(relatedQuery, relation)
 
-    return query.first()
+    const relatedRecords = this.mapRecords(relatedQuery.get(), this.ownerKey)
+
+    return collection.map((item) => {
+      const related = relatedRecords[item[this.foreignKey]]
+
+      return this.setRelated(item, related || null, relatedPath)
+    })
   }
 }

--- a/src/attributes/relations/HasOne.ts
+++ b/src/attributes/relations/HasOne.ts
@@ -1,4 +1,4 @@
-import { Record, NormalizedData, PlainItem } from '../../data/Contract'
+import { Record, NormalizedData, PlainCollection } from '../../data/Contract'
 import Model from '../../model/Model'
 import Repo, { Relation as Load } from '../../repo/Repo'
 import Relation from './Relation'
@@ -87,13 +87,19 @@ export default class HasOne extends Relation {
   /**
    * Load the has one relationship for the record.
    */
-  load (repo: Repo, record: Record, relation: Load): PlainItem {
-    const query = new Repo(repo.state, this.related.entity, false)
+  load (repo: Repo, collection: PlainCollection, relation: Load): PlainCollection {
+    const relatedPath = this.relatedPath(relation.name)
 
-    query.where(this.foreignKey, record[this.localKey])
+    const relatedQuery = new Repo(repo.state, this.related.entity, false)
 
-    this.addConstraint(query, relation)
+    this.addConstraint(relatedQuery, relation)
 
-    return query.first()
+    const relatedRecords = this.mapRecords(relatedQuery.get(), this.foreignKey)
+
+    return collection.map((item) => {
+      const related = relatedRecords[item[this.localKey]]
+
+      return this.setRelated(item, related || null, relatedPath)
+    })
   }
 }

--- a/src/attributes/relations/MorphOne.ts
+++ b/src/attributes/relations/MorphOne.ts
@@ -1,4 +1,4 @@
-import { Record, NormalizedData, PlainItem } from '../../data/Contract'
+import { Record, NormalizedData, PlainCollection } from '../../data/Contract'
 import Model from '../../model/Model'
 import Repo, { Relation as Load } from '../../repo/Repo'
 import Relation from './Relation'
@@ -85,13 +85,21 @@ export default class MorphOne extends Relation {
   /**
    * Load the morph many relationship for the record.
    */
-  load (repo: Repo, record: Record, relation: Load): PlainItem {
-    const query = new Repo(repo.state, this.related.entity, false)
+  load (repo: Repo, collection: PlainCollection, relation: Load): PlainCollection {
+    const relatedQuery = new Repo(repo.state, this.related.entity, false)
 
-    query.where(this.id, record[this.localKey]).where(this.type, repo.name)
+    relatedQuery.where(this.type, repo.name)
 
-    this.addConstraint(query, relation)
+    this.addConstraint(relatedQuery, relation)
 
-    return query.first()
+    const relatedRecords = this.mapRecords(relatedQuery.get(), this.id)
+
+    const relatedPath = this.relatedPath(relation.name)
+
+    return collection.map((item) => {
+      const related = relatedRecords[item[this.localKey]]
+
+      return this.setRelated(item, related || null, relatedPath)
+    })
   }
 }

--- a/src/attributes/relations/MorphToMany.ts
+++ b/src/attributes/relations/MorphToMany.ts
@@ -113,26 +113,38 @@ export default class MorphToMany extends Relation {
   /**
    * Load the morph many relationship for the record.
    */
-  load (repo: Repo, record: Record, relation: Load): PlainCollection {
-    const pivotQuery = new Repo(repo.state, this.pivot.entity, false)
-
-    const relatedItems = pivotQuery.where((rec: any) => {
-      return rec[this.id] === record[this.parentKey]
-    }).get()
-
-    if (relatedItems.length === 0) {
-      return []
-    }
-
-    const relatedIds = _.map(relatedItems, this.relatedId)
-
+  load (repo: Repo, collection: PlainCollection, relation: Load): PlainCollection {
     const relatedQuery = new Repo(repo.state, this.related.entity, false)
-
-    relatedQuery.where(this.relatedKey, (v: any) => _.includes(relatedIds, v))
 
     this.addConstraint(relatedQuery, relation)
 
-    return relatedQuery.get()
+    const relatedRecords = relatedQuery.get().reduce((records, record) => {
+      records[record[this.relatedKey]] = record
+
+      return records
+    }, {})
+
+    const pivotQuery = new Repo(repo.state, this.pivot.entity, false)
+
+    pivotQuery.where(this.type, repo.name)
+
+    const pivotRecords = pivotQuery.get().reduce((records, record) => {
+      if (!records[record[this.id]]) {
+        records[record[this.id]] = []
+      }
+
+      records[record[this.id]].push(relatedRecords[record[this.relatedId]])
+
+      return records
+    }, {} as any)
+
+    const relatedPath = this.relatedPath(relation.name)
+
+    return collection.map((item) => {
+      const related = pivotRecords[item[this.parentKey]]
+
+      return this.setRelated(item, related || [], relatedPath)
+    })
   }
 
   /**

--- a/src/attributes/relations/Relation.ts
+++ b/src/attributes/relations/Relation.ts
@@ -1,5 +1,6 @@
-import { Record, NormalizedData, PlainItem, PlainCollection } from '../../data/Contract'
+import { Record, Records, NormalizedData, PlainItem, PlainCollection } from '../../data/Contract'
 import Repo, { Relation as Load } from '../../repo/Repo'
+import { Fields } from '../contracts/Contract'
 import Attribute from '../Attribute'
 
 export default abstract class Relation extends Attribute {
@@ -11,7 +12,72 @@ export default abstract class Relation extends Attribute {
   /**
    * Load relationship records.
    */
-  abstract load (repo: Repo, record: Record, relation: Load): PlainItem | PlainCollection
+  abstract load (repo: Repo, collection: PlainCollection, relation: Load): PlainItem | PlainCollection
+
+  /**
+   * Create a new map of the record by given key.
+   */
+  mapRecords (records: Record[], key: string): Records {
+    return records.reduce((records, record) => {
+      return { ...records, [record[key]]: record }
+    }, {} as Records)
+  }
+
+  /**
+   * Get the path of the related field. It returns path as a dot-separated
+   * string something like `settings.accounts`.
+   */
+  relatedPath (key: string, fields?: Fields, parent?: string): string {
+    const _key = key.split('.')[0]
+    const _fields = fields || this.model.fields()
+
+    let path = ''
+
+    Object.keys(_fields).some((name) => {
+      if (name === _key) {
+        path = parent ? `${parent}.${_key}` : _key
+
+        return true
+      }
+
+      const field = _fields[name]
+
+      if (field instanceof Attribute) {
+        return false
+      }
+
+      const parentPath = parent ? `${parent}.${name}` : name
+      const nestedPath = this.relatedPath(_key, field, parentPath)
+
+      if (!nestedPath) {
+        return false
+      }
+
+      path = nestedPath
+
+      return true
+    })
+
+    return path
+  }
+
+  /**
+   * Set given related records to the item.
+   */
+  setRelated (item: Record, related: PlainItem | PlainCollection, path: string): Record {
+    const paths = path.split('.')
+    const length = paths.length - 1
+
+    let schema = item
+
+    for (let i = 0; i < length; i++) {
+      schema = schema[paths[i]]
+    }
+
+    schema[paths[length]] = related
+
+    return item
+  }
 
   /**
    * Add constraint to the query.

--- a/test/feature/relations/Relations_MorphToMany.spec.js
+++ b/test/feature/relations/Relations_MorphToMany.spec.js
@@ -63,8 +63,8 @@ describe('Features – Relations – Morph To Many', () => {
         {
           id: 2,
           tags: [
-            { id: 3, name: 'news' },
-            { id: 4, name: 'cast' }
+            { id: 1, name: 'news' },
+            { id: 2, name: 'cast' }
           ]
         }
       ]

--- a/test/performance/Retrieve_BelongsToMany.spec.js
+++ b/test/performance/Retrieve_BelongsToMany.spec.js
@@ -1,0 +1,72 @@
+import { createStore } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Performance – Retrieve – Belongs To Many', () => {
+  it('should retrieve belongsToMany relation in time', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr(''),
+          roles: this.belongsToMany(Role, RoleUser, 'user_id', 'role_id')
+        }
+      }
+    }
+
+    class Role extends Model {
+      static entity = 'roles'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          roleType: this.attr('')
+        }
+      }
+    }
+
+    class RoleUser extends Model {
+      static entity = 'roleUser'
+
+      static primaryKey = ['role_id', 'user_id']
+
+      static fields () {
+        return {
+          role_id: this.attr(null),
+          user_id: this.attr(null)
+        }
+      }
+    }
+
+    const users = []
+    const roles = []
+    const roleUser = []
+
+    for (let i = 1; i <= 2000; i++) {
+      users.push({ id: i })
+    }
+
+    for (let i = 1; i <= 2000; i++) {
+      roles.push({ id: i })
+    }
+
+    for (let i = 1; i <= 2000; i++) {
+      roleUser.push({ user_id: i, role_id: i })
+    }
+
+    const store = createStore([{ model: User }, { model: Role }, { model: RoleUser }])
+
+    await store.dispatch('entities/users/create', { data: users })
+    await store.dispatch('entities/roles/create', { data: roles })
+    await store.dispatch('entities/roleUser/create', { data: roleUser })
+
+    const start = new Date();
+
+    const result = store.getters['entities/users/query']().with('roles').get()
+
+    const end = new Date();
+
+    expect(end - start).toBeLessThan(100)
+  })
+})

--- a/test/performance/Retrieve_HasMany.spec.js
+++ b/test/performance/Retrieve_HasMany.spec.js
@@ -1,0 +1,52 @@
+import { createStore } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Performance – Retrieve – Has Many', () => {
+  it('should retrieve hasMany relation in time', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          posts: this.hasMany(Post, 'user_id')
+        }
+      }
+    }
+
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          user_id: this.attr(null)
+        }
+      }
+    }
+
+    const users = []
+    const posts = []
+
+    for (let i = 1; i <= 2000; i++) {
+      users.push({ id: i })
+    }
+
+    for (let i = 1; i <= 2000; i++) {
+      posts.push({ id: i })
+    }
+
+    const store = createStore([{ model: User }, { model: Post }])
+
+    await store.dispatch('entities/users/create', { data: users })
+    await store.dispatch('entities/posts/create', { data: posts })
+
+    const start = new Date();
+
+    const result = store.getters['entities/users/query']().with('posts').get()
+
+    const end = new Date();
+
+    expect(end - start).toBeLessThan(100)
+  })
+})

--- a/test/unit/repo/repo/Repo_Retrieve_Relations.spec.js
+++ b/test/unit/repo/repo/Repo_Retrieve_Relations.spec.js
@@ -428,24 +428,24 @@ describe('Repo – Retrieve – Relations', () => {
     const state = {
       name: 'entities',
       users: { data: {
-          '1': { $id: 1, id: 1, profile: 3 }
-        }},
+        '1': { $id: 1, id: 1, profile: 3 }
+      }},
       profiles: { data: {
-          '3': { $id: 3, id: 3, user_id: 1, users: 1 }
-        }},
+        '3': { $id: 3, id: 3, user_id: 1, users: 1 }
+      }},
       posts: { data: {
-          '1': { id: 1, user_id: 1, title: 'Post Title', reviews: [1, 2] }
-        }},
+        '1': { id: 1, user_id: 1, title: 'Post Title', reviews: [1, 2] }
+      }},
       comments: { data: {
-          '1': { id: 1, post_id: 1, type: 'review' }
-        }},
+        '1': { id: 1, post_id: 1, type: 'review' }
+      }},
       likes: { data: {
-          '1': { id: 1, comment_id: 1 }
-        }},
+        '1': { id: 1, comment_id: 1 }
+      }},
       reviews: { data: {
-          '1': { id: 1 },
-          '2': { id: 2 }
-        }}
+        '1': { id: 1 },
+        '2': { id: 2 }
+      }}
     }
 
     const expected1 = {
@@ -543,7 +543,7 @@ describe('Repo – Retrieve – Relations', () => {
     const expected = [{ $id: 2, id: 2 }]
 
     const users = Repo.query(state, 'users', false)
-      .has('posts', query => query.where('type', 'event'))
+      .whereHas('posts', query => query.where('type', 'event'))
       .get()
 
     expect(users).toEqual(expected)
@@ -567,55 +567,7 @@ describe('Repo – Retrieve – Relations', () => {
     const expected = [{ $id: 1, id: 1 }, { $id: 3, id: 3 }]
 
     const users = Repo.query(state, 'users', false)
-      .hasNot('posts', query => query.where('type', 'event'))
-      .get()
-
-    expect(users).toEqual(expected)
-  })
-
-  it('can query data depending on relationship existence with count', () => {
-    const state = {
-      name: 'entities',
-      users: { data: {
-        '1': { $id: 1, id: 1 },
-        '2': { $id: 2, id: 2 },
-        '3': { $id: 3, id: 3 }
-      }},
-      posts: { data: {
-        '1': { $id: 1, id: 1, user_id: 1, type: 'news' },
-        '2': { $id: 2, id: 2, user_id: 2, type: 'event' },
-        '3': { $id: 3, id: 3, user_id: 2, type: 'news' }
-      }}
-    }
-
-    const expected = [{ $id: 2, id: 2 }]
-
-    const users = Repo.query(state, 'users', false)
-      .has('posts', query => query.count() > 1)
-      .get()
-
-    expect(users).toEqual(expected)
-  })
-
-  it('can query data depending on relationship absence with count', () => {
-    const state = {
-      name: 'entities',
-      users: { data: {
-        '1': { $id: 1, id: 1 },
-        '2': { $id: 2, id: 2 },
-        '3': { $id: 3, id: 3 }
-      }},
-      posts: { data: {
-        '1': { $id: 1, id: 1, user_id: 1, type: 'news' },
-        '2': { $id: 2, id: 2, user_id: 2, type: 'event' },
-        '3': { $id: 3, id: 3, user_id: 2, type: 'news' }
-      }}
-    }
-
-    const expected = [{ $id: 1, id: 1 }, { $id: 3, id: 3 }]
-
-    const users = Repo.query(state, 'users', false)
-      .hasNot('posts', query => query.count() > 1)
+      .whereHasNot('posts', query => query.where('type', 'event'))
       .get()
 
     expect(users).toEqual(expected)

--- a/test/unit/repo/repo/Repo_Retrieve_Relations_MorphOne.spec.js
+++ b/test/unit/repo/repo/Repo_Retrieve_Relations_MorphOne.spec.js
@@ -52,7 +52,7 @@ describe('Repo – Retrieve – Relations – Morph One', () => {
       comments: {
         '1': { $id: '1', id: '1', body: 'comment1', commentable_id: 1, commentable_type: 'posts' },
         '2': { $id: '2', id: '2', body: 'comment2', commentable_id: 3, commentable_type: 'videos' },
-        '3': { $id: '3', id: '3', body: 'comment3', commentable_id: 1, commentable_type: 'posts' },
+        '3': { $id: '3', id: '3', body: 'comment3', commentable_id: 2, commentable_type: 'posts' },
         '4': { $id: '4', id: '4', body: 'comment4', commentable_id: 5, commentable_type: 'posts' }
       }
     })
@@ -170,7 +170,7 @@ describe('Repo – Retrieve – Relations – Morph One', () => {
       comments: {
         '1': { $id: '1', id: '1', body: 'comment1', commentable_id: 1, commentable_type: 'posts' },
         '2': { $id: '2', id: '2', body: 'comment2', commentable_id: 3, commentable_type: 'videos' },
-        '3': { $id: '3', id: '3', body: 'comment3', commentable_id: 1, commentable_type: 'posts' },
+        '3': { $id: '3', id: '3', body: 'comment3', commentable_id: 2, commentable_type: 'posts' },
         '4': { $id: '4', id: '4', body: 'comment4', commentable_id: 5, commentable_type: 'posts' }
       }
     })
@@ -232,7 +232,7 @@ describe('Repo – Retrieve – Relations – Morph One', () => {
       comments: {
         '1': { $id: '1', id: '1', body: 'comment1', commentable_id: 1, commentable_type: 'posts' },
         '2': { $id: '2', id: '2', body: 'comment2', commentable_id: 3, commentable_type: 'videos' },
-        '3': { $id: '3', id: '3', body: 'comment3', commentable_id: 1, commentable_type: 'posts' },
+        '3': { $id: '3', id: '3', body: 'comment3', commentable_id: 2, commentable_type: 'posts' },
         '4': { $id: '4', id: '4', body: 'comment4', commentable_id: 5, commentable_type: 'posts' }
       }
     })


### PR DESCRIPTION
Issue #113 

This PR drastically improves the performance when loading a large amount of relational data.

However, this PR will introduce some breaking changes on `has` and `hasNot` constraint.

Because there was a huge change in relation loading method, I had to separate `has` method for counting the record, and filtering the record.

In short, when a user wants to check relationship existence with the relationship count, a user must use `has` method. On the other hand, when a user wants to check relation existence with the value of the related record, a user must use `whereHas` method (the new method).

```js
store.getters['entities/users/query']().has('posts', 3).get()

store.getters['entities/users/query']().whereHas('posts', (post) => {
  post.where('published', true)
}).get()
```