### PR TITLE
#119 Fix where creating morph to many without relation field is failing

### DIFF
--- a/src/attributes/relations/MorphToMany.ts
+++ b/src/attributes/relations/MorphToMany.ts
@@ -154,7 +154,7 @@ export default class MorphToMany extends Relation {
     _.forEach(data[parent.entity], (record) => {
       const related = record[this.related.entity]
 
-      if (related.length === 0) {
+      if (!Array.isArray(related) || related.length === 0) {
         return
       }
 

--- a/test/feature/relations/Relations_MorphToMany.spec.js
+++ b/test/feature/relations/Relations_MorphToMany.spec.js
@@ -2,6 +2,66 @@ import { createStore } from 'test/support/Helpers'
 import Model from 'app/model/Model'
 
 describe('Features – Relations – Morph To Many', () => {
+  it('can create a morph to many data without relation field', async () => {
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          tags: this.morphToMany(Tag, Taggable, 'tag_id', 'taggable_id', 'taggable_type')
+        }
+      }
+    }
+
+    class Video extends Model {
+      static entity = 'videos'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          tags: this.morphToMany(Tag, Taggable, 'tag_id', 'taggable_id', 'taggable_type')
+        }
+      }
+    }
+
+    class Tag extends Model {
+      static entity = 'tags'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    class Taggable extends Model {
+      static entity = 'taggables'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          tag_id: this.attr(null),
+          taggable_id: this.attr(null),
+          taggable_type: this.attr(null)
+        }
+      }
+    }
+
+    const store = createStore([{ model: Post }, { model: Video }, { model: Tag }, { model: Taggable }])
+
+    await store.dispatch('entities/posts/create', {
+      data: { id: 1 }
+    })
+
+    const expected = {
+      '1': { $id: 1, id: 1, tags: [] }
+    }
+
+    expect(store.state.entities.posts.data).toEqual(expected)
+  })
+
   it('can resolve a morph to many relation', async () => {
     class Post extends Model {
       static entity = 'posts'


### PR DESCRIPTION
Issue #119

This PR fixes where creating morph to many without relation field is failing.