### PR TITLE
Fixes issue #113

### DIFF
--- a/src/data/PivotCreator.ts
+++ b/src/data/PivotCreator.ts
@@ -4,12 +4,14 @@ import { NormalizedData } from './Contract'
 
 export default class PivotCreator {
   static create (data: NormalizedData, Query: Query): NormalizedData {
-    if (!Query.model.hasPivotFields()) {
-      return data
-    }
+    Object.keys(data).forEach((key) => {
+      const model = Query.getModel(key)
 
-    _.forEach(Query.model.pivotFields(), (field) => {
-      _.forEach(field, attr => { attr.createPivots(Query.model, data) })
+      if (model.hasPivotFields()) {
+        _.forEach(model.pivotFields(), (field) => {
+          _.forEach(field, attr => { attr.createPivots(model, data) })
+        })
+      }
     })
 
     return data

--- a/test/unit/query/query/Query_Create_BelongsToMany.spec.js
+++ b/test/unit/query/query/Query_Create_BelongsToMany.spec.js
@@ -147,4 +147,97 @@ describe('Query – Create – Belongs To Many', () => {
 
     expect(state).toEqual(expected)
   })
+
+  it.only('can create a belongs to many relation data from nested data', () => {
+    class Team extends Model {
+      static entity = 'teams'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          users: this.hasMany(User, 'team_id')
+        }
+      }
+    }
+
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          team_id: this.attr(null),
+          roles: this.belongsToMany(Role, RoleUser, 'user_id', 'role_id')
+        }
+      }
+    }
+
+    class Role extends Model {
+      static entity = 'roles'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          users: this.belongsToMany(User, RoleUser, 'role_id', 'user_id')
+        }
+      }
+    }
+
+    class RoleUser extends Model {
+      static entity = 'roleUser'
+
+      static primaryKey = ['role_id', 'user_id']
+
+      static fields () {
+        return {
+          role_id: this.attr(null),
+          user_id: this.attr(null)
+        }
+      }
+    }
+
+    createApplication('entities', [{ model: Team }, { model: User }, { model: Role }, { model: RoleUser }])
+
+    const state = {
+      name: 'entities',
+      teams: { data: {} },
+      users: { data: {} },
+      roles: { data: {} },
+      roleUser: { data: {} }
+    }
+
+    const data = {
+      id: 1,
+      users: [{
+        team_id: 1,
+        id: 1,
+        roles: [
+          { id: 2 },
+          { id: 3 }
+        ]
+      }]
+    }
+
+    const expected = {
+      name: 'entities',
+      teams: { data: {
+        '1': { $id: 1, id: 1, users: [1] }
+      }},
+      users: { data: {
+        '1': { $id: 1, id: 1, team_id: 1, roles: [2, 3] }
+      }},
+      roles: { data: {
+        '2': { $id: 2, id: 2, users: [] },
+        '3': { $id: 3, id: 3, users: [] }
+      }},
+      roleUser: { data: {
+        '1_2': { $id: '1_2', user_id: 1, role_id: 2  },
+        '1_3': { $id: '1_3', user_id: 1, role_id: 3 }
+      }}
+    }
+
+    Query.create(state, 'teams', data)
+
+    expect(state).toEqual(expected)
+  })
 })


### PR DESCRIPTION
Fix for issue #113.

Fixes nested many to many relationship failing to create pivot table.

The solution is based on reading the keys of the normalized data, fetching the models for each key and creating the pivot tables accordingly. (Thanks to @kiaking, that suggested the solution)

- [x] Has regression test