### PR TITLE
#137 Fix where pivot table for the belongs to many not being created in certain case

### DIFF
--- a/src/attributes/relations/BelongsToMany.ts
+++ b/src/attributes/relations/BelongsToMany.ts
@@ -150,9 +150,9 @@ export default class BelongsToMany extends Relation {
   /**
    * Create pivot records for the given records if needed.
    */
-  createPivots (parent: typeof Model, data: NormalizedData): NormalizedData {
+  createPivots (parent: typeof Model, data: NormalizedData, key: string): NormalizedData {
     Utils.forOwn(data[parent.entity], (record) => {
-      const related = record[this.related.entity]
+      const related = record[key]
 
       if (related === undefined || related.length === 0) {
         return

--- a/src/data/processors/PivotCreator.ts
+++ b/src/data/processors/PivotCreator.ts
@@ -8,12 +8,12 @@ export default class PivotCreator {
    * require it for example `belongsTo` or `morphMany`.
    */
   static process (data: NormalizedData, Query: Query): NormalizedData {
-    Object.keys(data).forEach((key) => {
-      const model = Query.getModel(key)
+    Object.keys(data).forEach((entity) => {
+      const model = Query.getModel(entity)
 
       if (model.hasPivotFields()) {
         Utils.forOwn(model.pivotFields(), (field) => {
-          Utils.forOwn(field, attr => { attr.createPivots(model, data) })
+          Utils.forOwn(field, (attr, key) => { attr.createPivots(model, data, key) })
         })
       }
     })

--- a/test/feature/relations/Relations_BelongsToMany.spec.js
+++ b/test/feature/relations/Relations_BelongsToMany.spec.js
@@ -1,7 +1,68 @@
-import { createStore } from 'test/support/Helpers'
+import { createStore, createState } from 'test/support/Helpers'
 import Model from 'app/model/Model'
 
 describe('Features – Relations – Belongs To Many', () => {
+  it('can create a data with belongs to many relation', async () => {
+    class User extends Model {
+      static entity = "users"
+
+      static fields() {
+        return {
+          id: this.attr(null),
+          permissions: this.belongsToMany(Role, RoleUser, 'user_id', 'role_id')
+        }
+      }
+    }
+
+    class Role extends Model {
+      static entity = 'roles'
+
+      static fields() {
+        return {
+          id: this.attr(null)
+        }
+      }
+    }
+
+    class RoleUser extends Model {
+      static entity = 'roleUser'
+
+      static primaryKey = ['role_id', 'user_id']
+
+      static fields() {
+        return {
+          role_id: this.attr(null),
+          user_id: this.attr(null)
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }, { model: Role }, { model: RoleUser }])
+
+    await store.dispatch('entities/users/create', {
+      data: {
+        id: 1,
+        permissions: [{ id: 1 }, { id: 2 }]
+      }
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, permissions: [1, 2] }
+      },
+      roles: {
+        '1': { $id: 1, id: 1 },
+        '2': { $id: 2, id: 2 }
+      },
+      roleUser: {
+        '1_1': { $id: '1_1', role_id: 1, user_id: 1 },
+        '2_1': { $id: '2_1', role_id: 2, user_id: 1 }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
   it('can create a data without relation', async () => {
     class User extends Model {
       static entity = "users"
@@ -41,10 +102,14 @@ describe('Features – Relations – Belongs To Many', () => {
 
     await store.dispatch('entities/users/create', { data: { id: 1 } })
 
-    const users = store.getters['entities/users/all']()
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, roles: [] }
+      },
+      roles: {},
+      roleUser: {}
+    })
 
-    expect(users.length).toBe(1)
-    expect(users[0]).toBeInstanceOf(User)
-    expect(users[0].id).toBe(1)
+    expect(store.state.entities).toEqual(expected)
   })
 })


### PR DESCRIPTION
Issue #137 

This PR fixes where the pivot table for the belongsToMany relation won't get created if the name of the key that defines the relation is different from the entity name of the related model.