### PR TITLE
#110 Add specific type attributes

### DIFF
--- a/docs/advanced/accessors-and-mutators.md
+++ b/docs/advanced/accessors-and-mutators.md
@@ -53,7 +53,7 @@ Vuex ORM lets you define mutators which are going to modify the specific field w
 
 ### Via Attribute
 
-You can pass a closure to the 2nd argument of `attr` method. The closure takes the corresponding value as an argument, and you can modify the value however you want.
+You can pass a closure to the 2nd argument of `attr`, `string`, `number`, and `boolean` attribute. The closure takes the corresponding value as an argument, and you can modify the value however you want.
 
 ```js
 import { Model } from '@vuex-orm/core'

--- a/docs/components/models.md
+++ b/docs/components/models.md
@@ -126,6 +126,24 @@ class User extends Model {
 }
 ```
 
+## Specific Types
+
+You may use specific type attributes, `this.string()`, `this.number()`, and `this.boolean()` to cast the value to be those types. The argument is the default value.
+
+```js
+class User extends Model {
+  static fields () {
+    return {
+      id: this.number(0),
+      name: this.string('John Doe'),
+      active: this.boolean(true)
+    }
+  }
+}
+```
+
+Note that these attributes provide casting. It will convert for example `'0'` to be `0` or `1` to be `true`.
+
 ## Auto Increment Type
 
 `this.increment()` method will generate field type which will be auto incremented. Autoincrement field must be a number and should not have arguments. The value of this field gets incremented when you create a new record.

--- a/src/attributes/contracts/Contract.ts
+++ b/src/attributes/contracts/Contract.ts
@@ -1,5 +1,6 @@
 import Attr from '../types/Attr'
 import String from '../types/String'
+import Number from '../types/Number'
 import Increment from '../types/Increment'
 import HasOne from '../relations/HasOne'
 import BelongsTo from '../relations/BelongsTo'
@@ -41,6 +42,7 @@ export default class Contract {
   static isAttribute (attr: Field): attr is Attribute {
     return attr instanceof Attr
            || attr instanceof String
+           || attr instanceof Number
            || attr instanceof Increment
            || this.isRelation(attr)
   }

--- a/src/attributes/contracts/Contract.ts
+++ b/src/attributes/contracts/Contract.ts
@@ -1,6 +1,7 @@
 import Attr from '../types/Attr'
 import String from '../types/String'
 import Number from '../types/Number'
+import Boolean from '../types/Boolean'
 import Increment from '../types/Increment'
 import HasOne from '../relations/HasOne'
 import BelongsTo from '../relations/BelongsTo'
@@ -43,6 +44,7 @@ export default class Contract {
     return attr instanceof Attr
            || attr instanceof String
            || attr instanceof Number
+           || attr instanceof Boolean
            || attr instanceof Increment
            || this.isRelation(attr)
   }

--- a/src/attributes/contracts/Contract.ts
+++ b/src/attributes/contracts/Contract.ts
@@ -1,4 +1,5 @@
 import Attr from '../types/Attr'
+import String from '../types/String'
 import Increment from '../types/Increment'
 import HasOne from '../relations/HasOne'
 import BelongsTo from '../relations/BelongsTo'
@@ -39,6 +40,7 @@ export default class Contract {
    */
   static isAttribute (attr: Field): attr is Attribute {
     return attr instanceof Attr
+           || attr instanceof String
            || attr instanceof Increment
            || this.isRelation(attr)
   }

--- a/src/attributes/contracts/Type.ts
+++ b/src/attributes/contracts/Type.ts
@@ -1,6 +1,7 @@
 import Attr from '../types/Attr'
+import String from '../types/String'
 import Increment from '../types/Increment'
 
-type Types = Attr | Increment
+type Types = Attr | String | Increment
 
 export default Types

--- a/src/attributes/contracts/Type.ts
+++ b/src/attributes/contracts/Type.ts
@@ -1,8 +1,9 @@
 import Attr from '../types/Attr'
 import String from '../types/String'
 import Number from '../types/Number'
+import Boolean from '../types/Boolean'
 import Increment from '../types/Increment'
 
-type Types = Attr | String | Number | Increment
+type Types = Attr | String | Number | Boolean | Increment
 
 export default Types

--- a/src/attributes/contracts/Type.ts
+++ b/src/attributes/contracts/Type.ts
@@ -1,7 +1,8 @@
 import Attr from '../types/Attr'
 import String from '../types/String'
+import Number from '../types/Number'
 import Increment from '../types/Increment'
 
-type Types = Attr | String | Increment
+type Types = Attr | String | Number | Increment
 
 export default Types

--- a/src/attributes/types/Boolean.ts
+++ b/src/attributes/types/Boolean.ts
@@ -1,0 +1,58 @@
+import Record from '../../data/Record'
+import Model from '../../model/Model'
+import Type from './Type'
+
+export default class Boolean extends Type {
+  /**
+   * The default value of the field.
+   */
+  value: boolean
+
+  /**
+   * Create a new number instance.
+   */
+  constructor (model: typeof Model, value: boolean, mutator?: (value: any) => any) {
+    super(model, mutator) /* istanbul ignore next */
+
+    this.value = value
+  }
+
+  /**
+   * Transform given data to the appropriate value. This method will be called
+   * during data normalization to fix field that has an incorrect value,
+   * or add a missing field with the appropriate default value.
+   */
+  fill (value: any): boolean {
+    if (value === undefined) {
+      return this.value
+    }
+
+    if (typeof value === 'boolean') {
+      return value
+    }
+
+    if (typeof value === 'string') {
+      if (value.length === 0) {
+        return false
+      }
+
+      const int = parseInt(value, 0)
+
+      return isNaN(int) ? true : !!int
+    }
+
+    if (typeof value === 'number') {
+      return !!value
+    }
+
+    return false
+  }
+
+  /**
+   * Make value to be set to model property. This method is used when
+   * instantiating a model or creating a plain object from a model.
+   */
+  make (value: any, _parent: Record, key: string): any {
+    return this.mutate(this.fill(value), key)
+  }
+}

--- a/src/attributes/types/Number.ts
+++ b/src/attributes/types/Number.ts
@@ -1,0 +1,52 @@
+import Record from '../../data/Record'
+import Model from '../../model/Model'
+import Type from './Type'
+
+export default class Number extends Type {
+  /**
+   * The default value of the field.
+   */
+  value: number
+
+  /**
+   * Create a new number instance.
+   */
+  constructor (model: typeof Model, value: number, mutator?: (value: any) => any) {
+    super(model, mutator) /* istanbul ignore next */
+
+    this.value = value
+  }
+
+  /**
+   * Transform given data to the appropriate value. This method will be called
+   * during data normalization to fix field that has an incorrect value,
+   * or add a missing field with the appropriate default value.
+   */
+  fill (value: any): number {
+    if (value === undefined) {
+      return this.value
+    }
+
+    if (typeof value === 'number') {
+      return value
+    }
+
+    if (typeof value === 'string') {
+      return parseInt(value, 0)
+    }
+
+    if (typeof value === 'boolean') {
+      return value ? 1 : 0
+    }
+
+    return 0
+  }
+
+  /**
+   * Make value to be set to model property. This method is used when
+   * instantiating a model or creating a plain object from a model.
+   */
+  make (value: any, _parent: Record, key: string): any {
+    return this.mutate(this.fill(value), key)
+  }
+}

--- a/src/attributes/types/String.ts
+++ b/src/attributes/types/String.ts
@@ -2,16 +2,16 @@ import Record from '../../data/Record'
 import Model from '../../model/Model'
 import Type from './Type'
 
-export default class Attr extends Type {
+export default class String extends Type {
   /**
    * The default value of the field.
    */
-  value: any
+  value: string
 
   /**
-   * Create a new attr instance.
+   * Create a new string instance.
    */
-  constructor (model: typeof Model, value: any, mutator?: (value: any) => any) {
+  constructor (model: typeof Model, value: string, mutator?: (value: any) => any) {
     super(model, mutator) /* istanbul ignore next */
 
     this.value = value
@@ -22,8 +22,16 @@ export default class Attr extends Type {
    * during data normalization to fix field that has an incorrect value,
    * or add a missing field with the appropriate default value.
    */
-  fill (value: any): any {
-    return value !== undefined ? value : this.value
+  fill (value: any): string {
+    if (value === undefined) {
+      return this.value
+    }
+
+    if (typeof value === 'string') {
+      return value
+    }
+
+    return value + ''
   }
 
   /**

--- a/src/attributes/types/Type.ts
+++ b/src/attributes/types/Type.ts
@@ -1,3 +1,27 @@
+import Model from '../../model/Model'
 import Attribute from '../Attribute'
 
-export default abstract class Type extends Attribute {}
+export default abstract class Type extends Attribute {
+  /**
+   * The mutator for the field.
+   */
+  mutator?: (value: any) => any
+
+  /**
+   * Create a new type instance.
+   */
+  constructor (model: typeof Model, mutator?: (value: any) => any) {
+    super(model) /* istanbul ignore next */
+
+    this.mutator = mutator
+  }
+
+  /**
+   * Mutate the given value by mutator.
+   */
+  mutate (value: any, key: string): any {
+    const mutator = this.mutator || this.model.mutators()[key]
+
+    return mutator ? mutator(value) : value
+  }
+}

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -8,6 +8,7 @@ import Attribute from '../attributes/Attribute'
 import Attr from '../attributes/types/Attr'
 import String from '../attributes/types/String'
 import Number from '../attributes/types/Number'
+import Boolean from '../attributes/types/Boolean'
 import Increment from '../attributes/types/Increment'
 import HasOne from '../attributes/relations/HasOne'
 import BelongsTo from '../attributes/relations/BelongsTo'
@@ -76,6 +77,13 @@ export default class Model {
    */
   static number (value: any, mutator?: (value: any) => any): Number {
     return new Number(this, value, mutator)
+  }
+
+  /**
+   * Create a boolean attribute.
+   */
+  static boolean (value: any, mutator?: (value: any) => any): Boolean {
+    return new Boolean(this, value, mutator)
   }
 
   /**

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -5,7 +5,8 @@ import Connection from '../connections/Connection'
 import { Record, Records } from '../data'
 import AttrContract, { Fields } from '../attributes/contracts/Contract'
 import Attribute from '../attributes/Attribute'
-import Attr, { Mutator } from '../attributes/types/Attr'
+import Attr from '../attributes/types/Attr'
+import String from '../attributes/types/String'
 import Increment from '../attributes/types/Increment'
 import HasOne from '../attributes/relations/HasOne'
 import BelongsTo from '../attributes/relations/BelongsTo'
@@ -58,8 +59,15 @@ export default class Model {
    * Create an attr attribute. The given value will be used as a default
    * value for the field.
    */
-  static attr (value: any, mutator?: Mutator): Attr {
+  static attr (value: any, mutator?: (value: any) => any): Attr {
     return new Attr(this, value, mutator)
+  }
+
+  /**
+   * Create a string attribute.
+   */
+  static string (value: any, mutator?: (value: any) => any): String {
+    return new String(this, value, mutator)
   }
 
   /**

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -7,6 +7,7 @@ import AttrContract, { Fields } from '../attributes/contracts/Contract'
 import Attribute from '../attributes/Attribute'
 import Attr from '../attributes/types/Attr'
 import String from '../attributes/types/String'
+import Number from '../attributes/types/Number'
 import Increment from '../attributes/types/Increment'
 import HasOne from '../attributes/relations/HasOne'
 import BelongsTo from '../attributes/relations/BelongsTo'
@@ -68,6 +69,13 @@ export default class Model {
    */
   static string (value: any, mutator?: (value: any) => any): String {
     return new String(this, value, mutator)
+  }
+
+  /**
+   * Create a number attribute.
+   */
+  static number (value: any, mutator?: (value: any) => any): Number {
+    return new Number(this, value, mutator)
   }
 
   /**

--- a/test/feature/attributes/Boolean.spec.js
+++ b/test/feature/attributes/Boolean.spec.js
@@ -1,0 +1,75 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Attributes – Boolean', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        bool: this.boolean(true)
+      }
+    }
+  }
+
+  it('casts the value to `Boolean` when creating data', async () => {
+    const store = createStore([{ model: User }])
+
+    await store.dispatch('entities/users/create', {
+      data: [
+        { id: 1 },
+        { id: 2, bool: '' },
+        { id: 3, bool: 'string' },
+        { id: 4, bool: '0' },
+        { id: 5, bool: 0 },
+        { id: 6, bool: 1 },
+        { id: 7, bool: true },
+        { id: 8, bool: null }
+      ]
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, bool: true },
+        '2': { $id: 2, id: 2, bool: false },
+        '3': { $id: 3, id: 3, bool: true },
+        '4': { $id: 4, id: 4, bool: false },
+        '5': { $id: 5, id: 5, bool: false },
+        '6': { $id: 6, id: 6, bool: true },
+        '7': { $id: 7, id: 7, bool: true },
+        '8': { $id: 8, id: 8, bool: false }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('casts the value to `Boolean` when retrieving data', async () => {
+    const store = createStore([{ model: User }])
+
+    await store.dispatch('entities/users/create', {
+      data: [
+        { id: 1 },
+        { id: 2, bool: '' },
+        { id: 3, bool: 'string' },
+        { id: 4, bool: '0' },
+        { id: 5, bool: 0 },
+        { id: 6, bool: 1 },
+        { id: 7, bool: true },
+        { id: 8, bool: null }
+      ]
+    })
+
+    const users = store.getters['entities/users/all']()
+
+    expect(users[0].bool).toEqual(true)
+    expect(users[1].bool).toEqual(false)
+    expect(users[2].bool).toEqual(true)
+    expect(users[3].bool).toEqual(false)
+    expect(users[4].bool).toEqual(false)
+    expect(users[5].bool).toEqual(true)
+    expect(users[6].bool).toEqual(true)
+    expect(users[7].bool).toEqual(false)
+  })
+})

--- a/test/feature/attributes/Number.spec.js
+++ b/test/feature/attributes/Number.spec.js
@@ -1,0 +1,67 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Attributes – Number', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        num: this.number(0)
+      }
+    }
+  }
+
+  it('casts the value to `Number` when creating data', async () => {
+    const store = createStore([{ model: User }])
+
+    await store.dispatch('entities/users/create', {
+      data: [
+        { id: 1 },
+        { id: 2, num: 1 },
+        { id: 3, num: '2' },
+        { id: 4, num: true },
+        { id: 5, num: false },
+        { id: 6, num: null }
+      ]
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, num: 0 },
+        '2': { $id: 2, id: 2, num: 1 },
+        '3': { $id: 3, id: 3, num: 2 },
+        '4': { $id: 4, id: 4, num: 1 },
+        '5': { $id: 5, id: 5, num: 0 },
+        '6': { $id: 6, id: 6, num: 0 }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('casts the value to `Number` when retrieving data', async () => {
+    const store = createStore([{ model: User }])
+
+    await store.dispatch('entities/users/create', {
+      data: [
+        { id: 1 },
+        { id: 2, num: 1 },
+        { id: 3, num: '2' },
+        { id: 4, num: true },
+        { id: 5, num: false },
+        { id: 6, num: null }
+      ]
+    })
+
+    const users = store.getters['entities/users/all']()
+
+    expect(users[0].num).toEqual(0)
+    expect(users[1].num).toEqual(1)
+    expect(users[2].num).toEqual(2)
+    expect(users[3].num).toEqual(1)
+    expect(users[4].num).toEqual(0)
+    expect(users[5].num).toEqual(0)
+  })
+})

--- a/test/feature/attributes/String.spec.js
+++ b/test/feature/attributes/String.spec.js
@@ -1,0 +1,63 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Attributes – String', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        str: this.string('default')
+      }
+    }
+  }
+
+  it('casts the value to `String` when creating data', async () => {
+    const store = createStore([{ model: User }])
+
+    await store.dispatch('entities/users/create', {
+      data: [
+        { id: 1 },
+        { id: 2, str: 'value' },
+        { id: 3, str: 1 },
+        { id: 4, str: true },
+        { id: 5, str: null }
+      ]
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, str: 'default' },
+        '2': { $id: 2, id: 2, str: 'value' },
+        '3': { $id: 3, id: 3, str: '1' },
+        '4': { $id: 4, id: 4, str: 'true' },
+        '5': { $id: 5, id: 5, str: 'null' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('casts the value to `String` when retrieving data', async () => {
+    const store = createStore([{ model: User }])
+
+    await store.dispatch('entities/users/create', {
+      data: [
+        { id: 1 },
+        { id: 2, str: 'value' },
+        { id: 3, str: 1 },
+        { id: 4, str: true },
+        { id: 5, str: null }
+      ]
+    })
+
+    const users = store.getters['entities/users/all']()
+
+    expect(users[0].str).toEqual('default')
+    expect(users[1].str).toEqual('value')
+    expect(users[2].str).toEqual('1')
+    expect(users[3].str).toEqual('true')
+    expect(users[4].str).toEqual('null')
+  })
+})

--- a/test/unit/model/Model_Attributes_Boolean.spec.js
+++ b/test/unit/model/Model_Attributes_Boolean.spec.js
@@ -1,0 +1,77 @@
+import Model from 'app/model/Model'
+
+describe('Feature – Attributes – Boolean', () => {
+  it('casts the value to `Boolean` when instantiating the model', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          bool: this.boolean(true)
+        }
+      }
+    }
+
+    expect(new User({ id: 1 }).bool).toBe(true)
+    expect(new User({ id: 2, bool: '' }).bool).toBe(false)
+    expect(new User({ id: 3, bool: 'string' }).bool).toBe(true)
+    expect(new User({ id: 4, bool: '0' }).bool).toBe(false)
+    expect(new User({ id: 5, bool: 0 }).bool).toBe(false)
+    expect(new User({ id: 6, bool: 1 }).bool).toBe(true)
+    expect(new User({ id: 7, bool: true }).bool).toBe(true)
+    expect(new User({ id: 8, bool: null }).bool).toBe(false)
+  })
+
+  it('can mutate the value by specifying mutator at attribute', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          bool: this.boolean(true, value => !value)
+        }
+      }
+    }
+
+    expect(new User({ id: 1 }).bool).toBe(false)
+    expect(new User({ id: 2, bool: '' }).bool).toBe(true)
+    expect(new User({ id: 3, bool: 'string' }).bool).toBe(false)
+    expect(new User({ id: 4, bool: '0' }).bool).toBe(true)
+    expect(new User({ id: 5, bool: 0 }).bool).toBe(true)
+    expect(new User({ id: 6, bool: 1 }).bool).toBe(false)
+    expect(new User({ id: 7, bool: true }).bool).toBe(false)
+    expect(new User({ id: 8, bool: null }).bool).toBe(true)
+  })
+
+  it('can mutate the value by specifying mutator at mutators', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          bool: this.boolean(true)
+        }
+      }
+
+      static mutators () {
+        return {
+          bool (value) {
+            return !value
+          }
+        }
+      }
+    }
+
+    expect(new User({ id: 1 }).bool).toBe(false)
+    expect(new User({ id: 2, bool: '' }).bool).toBe(true)
+    expect(new User({ id: 3, bool: 'string' }).bool).toBe(false)
+    expect(new User({ id: 4, bool: '0' }).bool).toBe(true)
+    expect(new User({ id: 5, bool: 0 }).bool).toBe(true)
+    expect(new User({ id: 6, bool: 1 }).bool).toBe(false)
+    expect(new User({ id: 7, bool: true }).bool).toBe(false)
+    expect(new User({ id: 8, bool: null }).bool).toBe(true)
+  })
+})

--- a/test/unit/model/Model_Attributes_Number.spec.js
+++ b/test/unit/model/Model_Attributes_Number.spec.js
@@ -1,0 +1,71 @@
+import Model from 'app/model/Model'
+
+describe('Feature – Attributes – Number', () => {
+  it('casts the value to `Number` when instantiating the model', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          num: this.number(0)
+        }
+      }
+    }
+
+    expect((new User({})).num).toBe(0)
+    expect((new User({ num: 1 })).num).toBe(1)
+    expect((new User({ num: '2' })).num).toBe(2)
+    expect((new User({ num: true })).num).toBe(1)
+    expect((new User({ num: false })).num).toBe(0)
+    expect((new User({ num: null })).num).toBe(0)
+  })
+
+  it('can mutate the value by specifying mutator at attribute', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          num: this.number(0, value => value + 1)
+        }
+      }
+    }
+
+    expect((new User({})).num).toBe(1)
+    expect((new User({ num: 1 })).num).toBe(2)
+    expect((new User({ num: '2' })).num).toBe(3)
+    expect((new User({ num: true })).num).toBe(2)
+    expect((new User({ num: false })).num).toBe(1)
+    expect((new User({ num: null })).num).toBe(1)
+  })
+
+  it('can mutate the value by specifying mutator at mutators', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          num: this.number(0)
+        }
+      }
+
+      static mutators () {
+        return {
+          num (value) {
+            return value + 1
+          }
+        }
+      }
+    }
+
+    expect((new User({})).num).toBe(1)
+    expect((new User({ num: 1 })).num).toBe(2)
+    expect((new User({ num: '2' })).num).toBe(3)
+    expect((new User({ num: true })).num).toBe(2)
+    expect((new User({ num: false })).num).toBe(1)
+    expect((new User({ num: null })).num).toBe(1)
+  })
+})

--- a/test/unit/model/Model_Attributes_String.spec.js
+++ b/test/unit/model/Model_Attributes_String.spec.js
@@ -1,0 +1,68 @@
+import Model from 'app/model/Model'
+
+describe('Feature – Attributes – String', () => {
+  it('casts the value to `String` when instantiating the model', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          str: this.string('default')
+        }
+      }
+    }
+
+    expect((new User({})).str).toBe('default')
+    expect((new User({ str: 'value' })).str).toBe('value')
+    expect((new User({ str: 1 })).str).toBe('1')
+    expect((new User({ str: true })).str).toBe('true')
+    expect((new User({ str: null })).str).toBe('null')
+  })
+
+  it('can mutate the value by specifying mutator at attribute', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          str: this.string('default', value => `${value} mutated`)
+        }
+      }
+    }
+
+    expect((new User({})).str).toBe('default mutated')
+    expect((new User({ str: 'value' })).str).toBe('value mutated')
+    expect((new User({ str: 1 })).str).toBe('1 mutated')
+    expect((new User({ str: true })).str).toBe('true mutated')
+    expect((new User({ str: null })).str).toBe('null mutated')
+  })
+
+  it('can mutate the value by specifying mutator at mutators', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          str: this.string('default')
+        }
+      }
+
+      static mutators () {
+        return {
+          str (value) {
+            return `${value} mutated`
+          }
+        }
+      }
+    }
+
+    expect((new User({})).str).toBe('default mutated')
+    expect((new User({ str: 'value' })).str).toBe('value mutated')
+    expect((new User({ str: 1 })).str).toBe('1 mutated')
+    expect((new User({ str: true })).str).toBe('true mutated')
+    expect((new User({ str: null })).str).toBe('null mutated')
+  })
+})


### PR DESCRIPTION
Issue #110 

This PR adds specific type attributes that can be defined as model fields such as `this.string` or `this.number`.

- [x] String
- [x] Number
- [x] Boolean

#### TODO

- [x] Add documentation.