### PR TITLE
#60 Add convenience model methods

### DIFF
--- a/docs/advanced/interact-with-store-from-model.md
+++ b/docs/advanced/interact-with-store-from-model.md
@@ -1,6 +1,6 @@
 # Advanced: Interact With Store From Model
 
-Alternative for calling store methods directly, you may access store instance from a model as well to dispatch actions or call getters.
+Alternative for calling store methods directly, you may access store instance from a model as well to dispatch actions or call getters. 
 
 ```js
 const user = User.dispatch('create', { data: ... })
@@ -8,6 +8,19 @@ const user = User.dispatch('create', { data: ... })
 // The above code is exactly same as below.
 
 const user = store.dispatch('entities/users/create', { data: ... })
+```
+
+Also, the model is capable of calling all of the store actions and getters such as `create` and `find`.
+
+```js
+User.create({
+  data: [
+    { id: 1, name: 'John Doe' },
+    { id: 2, name: 'Jane Doe' }
+  ]
+})
+
+const user = User.find(2)
 ```
 
 Accessing store from a model does nothing special compared to accessing the store directly. It's just for the convenience. Hence you may choose whichever way that fits your preference.
@@ -63,3 +76,52 @@ const users = user.$getters('all')()
 ```
 
 As same as actions, getters in the model is also namespaced automatically.
+
+## Dispatching Persist Method
+
+The model can dispatch all of the persist methods, which are `create`, `insert`, `update` and `insertOrUpdate`. You may call them through static and instance method. Note that you need to prefix the method name with `$` when dispatching methods by instance method.
+
+```js
+// As static method.
+
+User.create({ data: { ... } })
+
+// As instance method.
+
+const user = new User()
+
+const users = user.$create({ data: { ... } })
+```
+
+When calling `update` as an instance method, you may omit the primary key since the model instance already has it.
+
+```js
+const user = User.find(1)
+
+user.$update({ age: 24 }) // <- Updates where user has id of 1.
+```
+
+## Dispatching Persist Method
+
+You may call getters through models as well. All `all`, `find` and `query` getters are available.
+
+```js
+const users = User.all()
+
+// You can chain the query too.
+const users = User.query().where('active', true).get()
+```
+
+## Delete Method
+
+You can call delete actions through models as same as other methods. Like `update`, you may omit the primary key value when calling delete method through instance method.
+
+```js
+User.delete(1)
+
+// You can omit id with instance method.
+
+const user = User.find(1)
+
+user.$delete()
+```

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -300,6 +300,13 @@ export default class Model {
   }
 
   /**
+   * Insert or update records.
+   */
+  static async insertOrUpdate (payload: any): Promise<EntityCollection> {
+    return this.dispatch('insertOrUpdate', payload)
+  }
+
+  /**
    * Get the value of the primary key.
    */
   static id (record: any): any {
@@ -593,6 +600,13 @@ export default class Model {
     }
 
     return this.$dispatch('update', payload)
+  }
+
+  /**
+   * Insert or update records.
+   */
+  async $insertOrUpdate (payload: any): Promise<EntityCollection> {
+    return this.$dispatch('insertOrUpdate', payload)
   }
 
   /**

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -286,6 +286,13 @@ export default class Model {
   }
 
   /**
+   * Insert records.
+   */
+  static async insert (payload: { data: Record | Record[], create: string, insert: string, update: string, insertOrUpdate: string }): Promise<EntityCollection> {
+    return this.dispatch('insert', payload)
+  }
+
+  /**
    * Get the value of the primary key.
    */
   static id (record: any): any {
@@ -557,6 +564,13 @@ export default class Model {
    */
   async $create (payload: { data: Record | Record[], create: string, insert: string, update: string, insertOrUpdate: string }): Promise<EntityCollection> {
     return this.$dispatch('create', payload)
+  }
+
+  /**
+   * Create records.
+   */
+  async $insert (payload: { data: Record | Record[], create: string, insert: string, update: string, insertOrUpdate: string }): Promise<EntityCollection> {
+    return this.$dispatch('insert', payload)
   }
 
   /**

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -25,6 +25,7 @@ import Query from '../query/Query'
 import Item from '../query/Item'
 import Collection from '../query/Collection'
 import EntityCollection from '../query/EntityCollection'
+import * as Payloads from '../modules/Payloads'
 
 export default class Model {
   /**
@@ -284,28 +285,28 @@ export default class Model {
   /**
    * Create records.
    */
-  static async create (payload: any): Promise<EntityCollection> {
+  static async create (payload: Payloads.CreatePayload): Promise<EntityCollection> {
     return this.dispatch('create', payload)
   }
 
   /**
    * Insert records.
    */
-  static async insert (payload: any): Promise<EntityCollection> {
+  static async insert (payload: Payloads.InsertPayload): Promise<EntityCollection> {
     return this.dispatch('insert', payload)
   }
 
   /**
    * Update records.
    */
-  static async update (payload: any): Promise<EntityCollection> {
+  static async update (payload: Payloads.UpdatePayload): Promise<EntityCollection> {
     return this.dispatch('update', payload)
   }
 
   /**
    * Insert or update records.
    */
-  static async insertOrUpdate (payload: any): Promise<EntityCollection> {
+  static async insertOrUpdate (payload: Payloads.InsertOrUpdatePayload): Promise<EntityCollection> {
     return this.dispatch('insertOrUpdate', payload)
   }
 
@@ -333,7 +334,7 @@ export default class Model {
   /**
    * Insert or update records.
    */
-  static async delete (condition: any): Promise<Item | Collection> {
+  static async delete (condition: Payloads.DeletePaylaod): Promise<Item | Collection> {
     return this.dispatch('delete', condition)
   }
 
@@ -607,21 +608,21 @@ export default class Model {
   /**
    * Create records.
    */
-  async $create (payload: any): Promise<EntityCollection> {
+  async $create (payload: Payloads.CreatePayload): Promise<EntityCollection> {
     return this.$dispatch('create', payload)
   }
 
   /**
    * Create records.
    */
-  async $insert (payload: any): Promise<EntityCollection> {
+  async $insert (payload: Payloads.InsertPayload): Promise<EntityCollection> {
     return this.$dispatch('insert', payload)
   }
 
   /**
    * Update records.
    */
-  async $update (payload: any): Promise<EntityCollection> {
+  async $update (payload: Payloads.UpdatePayload): Promise<EntityCollection> {
     if (payload.where !== undefined) {
       return this.$dispatch('update', payload)
     }
@@ -636,7 +637,7 @@ export default class Model {
   /**
    * Insert or update records.
    */
-  async $insertOrUpdate (payload: any): Promise<EntityCollection> {
+  async $insertOrUpdate (payload: Payloads.InsertOrUpdatePayload): Promise<EntityCollection> {
     return this.$dispatch('insertOrUpdate', payload)
   }
 
@@ -664,7 +665,7 @@ export default class Model {
   /**
    * Insert or update records.
    */
-  async $delete (condition: any): Promise<Item | Collection> {
+  async $delete (condition?: Payloads.DeletePaylaod): Promise<Item | Collection> {
     condition = condition === undefined ? this.$id() : condition
 
     return this.$dispatch('delete', condition)

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -21,6 +21,7 @@ import MorphOne from '../attributes/relations/MorphOne'
 import MorphMany from '../attributes/relations/MorphMany'
 import MorphToMany from '../attributes/relations/MorphToMany'
 import MorphedByMany from '../attributes/relations/MorphedByMany'
+import EntityCollection from '../query/EntityCollection'
 
 export default class Model {
   /**
@@ -275,6 +276,13 @@ export default class Model {
    */
   static getters (method: string): any {
     return this.store().getters[this.namespace(method)]
+  }
+
+  /**
+   * Create records.
+   */
+  static async create (payload: { data: Record | Record[], create: string, insert: string, update: string, insertOrUpdate: string }): Promise<EntityCollection> {
+    return this.dispatch('create', payload)
   }
 
   /**
@@ -542,6 +550,13 @@ export default class Model {
    */
   $getters (method: string): any {
     return this.$self().getters(method)
+  }
+
+  /**
+   * Create records.
+   */
+  async $create (payload: { data: Record | Record[], create: string, insert: string, update: string, insertOrUpdate: string }): Promise<EntityCollection> {
+    return this.$dispatch('create', payload)
   }
 
   /**

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -281,15 +281,22 @@ export default class Model {
   /**
    * Create records.
    */
-  static async create (payload: { data: Record | Record[], create: string, insert: string, update: string, insertOrUpdate: string }): Promise<EntityCollection> {
+  static async create (payload: any): Promise<EntityCollection> {
     return this.dispatch('create', payload)
   }
 
   /**
    * Insert records.
    */
-  static async insert (payload: { data: Record | Record[], create: string, insert: string, update: string, insertOrUpdate: string }): Promise<EntityCollection> {
+  static async insert (payload: any): Promise<EntityCollection> {
     return this.dispatch('insert', payload)
+  }
+
+  /**
+   * Update records.
+   */
+  static async update (payload: any): Promise<EntityCollection> {
+    return this.dispatch('update', payload)
   }
 
   /**
@@ -562,15 +569,30 @@ export default class Model {
   /**
    * Create records.
    */
-  async $create (payload: { data: Record | Record[], create: string, insert: string, update: string, insertOrUpdate: string }): Promise<EntityCollection> {
+  async $create (payload: any): Promise<EntityCollection> {
     return this.$dispatch('create', payload)
   }
 
   /**
    * Create records.
    */
-  async $insert (payload: { data: Record | Record[], create: string, insert: string, update: string, insertOrUpdate: string }): Promise<EntityCollection> {
+  async $insert (payload: any): Promise<EntityCollection> {
     return this.$dispatch('insert', payload)
+  }
+
+  /**
+   * Update records.
+   */
+  async $update (payload: any): Promise<EntityCollection> {
+    if (payload.where !== undefined) {
+      return this.$dispatch('update', payload)
+    }
+
+    if (this.$self().id(payload) === undefined) {
+      return this.$dispatch('update', { where: this.$id(), data: payload })
+    }
+
+    return this.$dispatch('update', payload)
   }
 
   /**

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -21,6 +21,7 @@ import MorphOne from '../attributes/relations/MorphOne'
 import MorphMany from '../attributes/relations/MorphMany'
 import MorphToMany from '../attributes/relations/MorphToMany'
 import MorphedByMany from '../attributes/relations/MorphedByMany'
+import Query from '../query/Query'
 import Item from '../query/Item'
 import Collection from '../query/Collection'
 import EntityCollection from '../query/EntityCollection'
@@ -306,6 +307,27 @@ export default class Model {
    */
   static async insertOrUpdate (payload: any): Promise<EntityCollection> {
     return this.dispatch('insertOrUpdate', payload)
+  }
+
+  /**
+   * Get all records.
+   */
+  static all (): Collection {
+    return this.getters('all')()
+  }
+
+  /**
+   * Find a record.
+   */
+  static find (id: string | number): Collection {
+    return this.getters('find')(id)
+  }
+
+  /**
+   * Get query instance.
+   */
+  static query (): Query {
+    return this.getters('query')()
   }
 
   /**
@@ -616,6 +638,27 @@ export default class Model {
    */
   async $insertOrUpdate (payload: any): Promise<EntityCollection> {
     return this.$dispatch('insertOrUpdate', payload)
+  }
+
+  /**
+   * Get all records.
+   */
+  $all (): Collection {
+    return this.$getters('all')()
+  }
+
+  /**
+   * Find a record.
+   */
+  $find (id: string | number): Collection {
+    return this.$getters('find')(id)
+  }
+
+  /**
+   * Get query instance.
+   */
+  $query (): Query {
+    return this.$getters('query')()
   }
 
   /**

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -21,6 +21,8 @@ import MorphOne from '../attributes/relations/MorphOne'
 import MorphMany from '../attributes/relations/MorphMany'
 import MorphToMany from '../attributes/relations/MorphToMany'
 import MorphedByMany from '../attributes/relations/MorphedByMany'
+import Item from '../query/Item'
+import Collection from '../query/Collection'
 import EntityCollection from '../query/EntityCollection'
 
 export default class Model {
@@ -304,6 +306,13 @@ export default class Model {
    */
   static async insertOrUpdate (payload: any): Promise<EntityCollection> {
     return this.dispatch('insertOrUpdate', payload)
+  }
+
+  /**
+   * Insert or update records.
+   */
+  static async delete (condition: any): Promise<Item | Collection> {
+    return this.dispatch('delete', condition)
   }
 
   /**
@@ -607,6 +616,15 @@ export default class Model {
    */
   async $insertOrUpdate (payload: any): Promise<EntityCollection> {
     return this.$dispatch('insertOrUpdate', payload)
+  }
+
+  /**
+   * Insert or update records.
+   */
+  async $delete (condition: any): Promise<Item | Collection> {
+    condition = condition === undefined ? this.$id() : condition
+
+    return this.$dispatch('delete', condition)
   }
 
   /**

--- a/src/modules/Payloads.ts
+++ b/src/modules/Payloads.ts
@@ -1,0 +1,43 @@
+import { Record } from '../data'
+
+export type Condition = (record: Record) => boolean)
+
+export interface CreatePayload {
+  data: Record | Record[]
+  create?: string[]
+  insert?: string[]
+  update?: string[]
+  insertOrUpdate?: string[]
+}
+
+export interface InsertPayload {
+  data: Record | Record[]
+  create?: string[]
+  insert?: string[]
+  update?: string[]
+  insertOrUpdate?: string[]
+}
+
+export interface UpdatePayload {
+  where?: string | number | Condition
+  data?: Record | Record[]
+  create?: string[]
+  insert?: string[]
+  update?: string[]
+  insertOrUpdate?: string[]
+  [key: string]: any
+}
+
+export interface InsertOrUpdatePayload {
+  data: Record | Record[]
+  create?: string[]
+  insert?: string[]
+  update?: string[]
+  insertOrUpdate?: string[]
+}
+
+export type DeletePaylaod = string | number | Condition | DeletePayloadObject
+
+export interface DeletePayloadObject {
+  where: string | number
+}

--- a/src/modules/subActions.ts
+++ b/src/modules/subActions.ts
@@ -1,5 +1,6 @@
 import * as Vuex from 'vuex'
 import EntityState from './EntityState'
+import * as Paylods from './Payloads'
 
 export type SubActions = Vuex.ActionTree<EntityState, any>
 
@@ -9,7 +10,7 @@ const subActions: SubActions = {
    * state. If you want to keep existing data while saving new data,
    * use `insert` instead.
    */
-  create ({ dispatch, state }, payload) {
+  create ({ dispatch, state }, payload: Paylods.CreatePayload) {
     return dispatch(`${state.$connection}/create`, { entity: state.$name, ...payload }, { root: true })
   },
 
@@ -18,14 +19,14 @@ const subActions: SubActions = {
    * remove existing data within the state, but it will update the data
    * with the same primary key.
    */
-  insert ({ dispatch, state }, payload) {
+  insert ({ dispatch, state }, payload: Paylods.InsertPayload) {
     return dispatch(`${state.$connection}/insert`, { entity: state.$name, ...payload }, { root: true })
   },
 
   /**
    * Update data in the store.
    */
-  update ({ dispatch, state }, payload) {
+  update ({ dispatch, state }, payload: Paylods.UpdatePayload) {
     const { where, data } = payload
 
     if (where === undefined || data === undefined) {
@@ -40,14 +41,14 @@ const subActions: SubActions = {
    * will not replace existing data within the state, but it will update only
    * the submitted data with the same primary key.
    */
-  insertOrUpdate ({ dispatch, state }, payload) {
+  insertOrUpdate ({ dispatch, state }, payload: Paylods.InsertOrUpdatePayload) {
     return dispatch(`${state.$connection}/insertOrUpdate`, { entity: state.$name, ...payload }, { root: true })
   },
 
   /**
    * Delete data from the store.
    */
-  delete ({ dispatch, state }, condition) {
+  delete ({ dispatch, state }, condition: Paylods.DeletePaylaod) {
     const where = typeof condition === 'object' ? condition.where : condition
 
     return dispatch(`${state.$connection}/delete`, { entity: state.$name, where }, { root: true })

--- a/test/feature/models/All.spec.js
+++ b/test/feature/models/All.spec.js
@@ -1,0 +1,59 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Models – All', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        name: this.attr('')
+      }
+    }
+  }
+
+  it('can fetch all records via static method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const users = User.all()
+
+    const expected = [
+      { id: 1, name: 'John Doe' },
+      { id: 2, name: 'Jane Doe' }
+    ]
+
+    expect(users).toEqual(expected)
+    expect(users[0]).toBeInstanceOf(User)
+  })
+
+  it('can fetch all records via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const user = new User()
+
+    const users = user.$all()
+
+    const expected = [
+      { id: 1, name: 'John Doe' },
+      { id: 2, name: 'Jane Doe' }
+    ]
+
+    expect(users).toEqual(expected)
+    expect(users[0]).toBeInstanceOf(User)
+  })
+})

--- a/test/feature/models/Create.spec.js
+++ b/test/feature/models/Create.spec.js
@@ -1,0 +1,121 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Models – Create', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        name: this.attr('')
+      }
+    }
+  }
+
+  it('can create a record via static method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.create({
+      data: { id: 1, name: 'John Doe' }
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can create list of record via static method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.create({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' },
+        '2': { $id: 2, id: 2, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('returns created records via static method', async () => {
+    createStore([{ model: User }])
+
+    const data = await User.create({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    expect(data.users.length).toBe(2)
+    expect(data.users[0]).toBeInstanceOf(User)
+  })
+
+  it('can create a record via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    const user = new User()
+
+    await user.$create({
+      data: { id: 1, name: 'John Doe' }
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can create list of record via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    const user = new User()
+
+    await user.$create({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' },
+        '2': { $id: 2, id: 2, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('returns created records via instance method', async () => {
+    createStore([{ model: User }])
+
+    const user = new User()
+
+    const data = await user.$create({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    expect(data.users.length).toBe(2)
+    expect(data.users[0]).toBeInstanceOf(User)
+  })
+})

--- a/test/feature/models/Delete.spec.js
+++ b/test/feature/models/Delete.spec.js
@@ -1,0 +1,125 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Models – Delete', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        name: this.attr('')
+      }
+    }
+  }
+
+  it('can delete a record via static method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    await User.delete(2)
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can delete a record via static method by passing where value', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    await User.delete({ where: 2 })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can delete records via static method by passing closure', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' },
+        { id: 3, name: 'Jane Doe' }
+      ]
+    })
+
+    await User.delete(record => record.name === 'Jane Doe')
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can delete a record via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    const user = new User()
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    await user.$delete(2)
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can omit condition when deleting a record via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const user = store.getters['entities/users/find'](2)
+
+    await user.$delete()
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+})

--- a/test/feature/models/Find.spec.js
+++ b/test/feature/models/Find.spec.js
@@ -1,0 +1,53 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Models – Find', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        name: this.attr('')
+      }
+    }
+  }
+
+  it('can fetch a record via static method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const user = User.find(1)
+
+    const expected = { id: 1, name: 'John Doe' }
+
+    expect(user).toEqual(expected)
+    expect(user).toBeInstanceOf(User)
+  })
+
+  it('can fetch a record via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const u = new User()
+
+    const user = u.$find(1)
+
+    const expected = { id: 1, name: 'John Doe' }
+
+    expect(user).toEqual(expected)
+    expect(user).toBeInstanceOf(User)
+  })
+})

--- a/test/feature/models/Insert.spec.js
+++ b/test/feature/models/Insert.spec.js
@@ -1,0 +1,131 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Models – Insert', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        name: this.attr('')
+      }
+    }
+  }
+
+  it('can insert a record via static method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: { id: 1, name: 'John Doe' }
+    })
+
+    await User.insert({
+      data: { id: 2, name: 'Jane Doe' }
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' },
+        '2': { $id: 2, id: 2, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can insert list of record via static method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' },
+        '2': { $id: 2, id: 2, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('returns inserted records via static method', async () => {
+    createStore([{ model: User }])
+
+    const data = await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    expect(data.users.length).toBe(2)
+    expect(data.users[0]).toBeInstanceOf(User)
+  })
+
+  it('can insert a record via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    const user = new User()
+
+    await user.$insert({
+      data: { id: 1, name: 'John Doe' }
+    })
+
+    await user.$insert({
+      data: { id: 2, name: 'Jane Doe' }
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' },
+        '2': { $id: 2, id: 2, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can insert list of record via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    const user = new User()
+
+    await user.$insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' },
+        '2': { $id: 2, id: 2, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('returns inserted records via instance method', async () => {
+    createStore([{ model: User }])
+
+    const user = new User()
+
+    const data = await user.$insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    expect(data.users.length).toBe(2)
+    expect(data.users[0]).toBeInstanceOf(User)
+  })
+})

--- a/test/feature/models/InsertOrUpdate.spec.js
+++ b/test/feature/models/InsertOrUpdate.spec.js
@@ -1,0 +1,69 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Models – Insert Or Update', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        name: this.attr('')
+      }
+    }
+  }
+
+  it('can insert or update records via static method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' }
+      ]
+    })
+
+    await User.insertOrUpdate({
+      data: [
+        { id: 1, name: 'Jane Doe' },
+        { id: 2, name: 'Johnny Doe' }
+      ]
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'Jane Doe' },
+        '2': { $id: 2, id: 2, name: 'Johnny Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can insert or update records via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    const user = new User()
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' }
+      ]
+    })
+
+    await user.$insertOrUpdate({
+      data: [
+        { id: 1, name: 'Jane Doe' },
+        { id: 2, name: 'Johnny Doe' }
+      ]
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'Jane Doe' },
+        '2': { $id: 2, id: 2, name: 'Johnny Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+})

--- a/test/feature/models/Query.spec.js
+++ b/test/feature/models/Query.spec.js
@@ -1,0 +1,56 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Models – Query', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        name: this.attr('')
+      }
+    }
+  }
+
+  it('can begin query chain via static method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const users = User.query().get()
+
+    const expected = [
+      { id: 1, name: 'John Doe' },
+      { id: 2, name: 'Jane Doe' }
+    ]
+
+    expect(users).toEqual(expected)
+    expect(users[0]).toBeInstanceOf(User)
+  })
+
+  it('can begin query chain via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' }
+      ]
+    })
+
+    const u = new User()
+
+    const user = u.$query().find(1)
+
+    const expected = { id: 1, name: 'John Doe' }
+
+    expect(user).toEqual(expected)
+    expect(user).toBeInstanceOf(User)
+  })
+})

--- a/test/feature/models/Update.spec.js
+++ b/test/feature/models/Update.spec.js
@@ -1,0 +1,177 @@
+import { createStore, createState } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Models – Update', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.attr(null),
+        name: this.attr('')
+      }
+    }
+  }
+
+  it('can update a record via static method by passing in the id', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: { id: 1, name: 'John Doe' }
+    })
+
+    await User.update({ id: 1, name: 'Jane Doe' })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can update a record by passing where value', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: { id: 1, name: 'John Doe' }
+    })
+
+    await User.update({
+      where: 1,
+      data: { name: 'Jane Doe' }
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can update records by passing where closure', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' },
+        { id: 3, name: 'Jane Doe' }
+      ]
+    })
+
+    await User.update({
+      where (record) {
+        return record.name === 'Jane Doe'
+      },
+
+      data: { name: 'John Doe' }
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'John Doe' },
+        '2': { $id: 2, id: 2, name: 'John Doe' },
+        '3': { $id: 3, id: 3, name: 'John Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can update a record by passing data closure', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: [
+        { id: 1, name: 'John Doe' },
+        { id: 2, name: 'Jane Doe' },
+        { id: 3, name: 'Jane Doe' }
+      ]
+    })
+
+    await User.update({
+      where: 1,
+
+      data (record) {
+        record.name = 'Jane Doe'
+      }
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'Jane Doe' },
+        '2': { $id: 2, id: 2, name: 'Jane Doe' },
+        '3': { $id: 3, id: 3, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can update a record via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    const user = new User()
+
+    await User.insert({
+      data: { id: 1, name: 'John Doe' }
+    })
+
+    await user.$update({ id: 1, name: 'Jane Doe' })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can omit id when updating via instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: { id: 1, name: 'John Doe' }
+    })
+
+    const user = store.getters['entities/users/find'](1)
+
+    await user.$update({ name: 'Jane Doe' })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
+  it('can update a record by passing where value to the instance method', async () => {
+    const store = createStore([{ model: User }])
+
+    const user = new User()
+
+    await User.insert({
+      data: { id: 1, name: 'John Doe' }
+    })
+
+    await user.$update({
+      where: 1,
+      data: { name: 'Jane Doe' }
+    })
+
+    const expected = createState('entities', {
+      users: {
+        '1': { $id: 1, id: 1, name: 'Jane Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+})


### PR DESCRIPTION
Issue #60 

This PR adds convenience methods to the model where you can dispatch actions or getters such as `create` and `find`.

#### TODO

- [x] Add types to the method argument.
- [x] Add documentation.