### PR TITLE
#104 Nested `with` constraints

### DIFF
--- a/docs/guide/components/modules-and-store.md
+++ b/docs/guide/components/modules-and-store.md
@@ -86,4 +86,4 @@ const count = store.state.users.count
 store.commit('entities/users/add', 3)
 ```
 
-However, Vuex ORM has predefined getters, actions, and mutations to store, modify and search data. See [Interacting With Store](../interacting-with-store.md) for the usage.
+However, Vuex ORM has predefined getters, actions, and mutations to store, modify and search data. See [Interacting With Store](../store/retrieving-data.md) for the usage.

--- a/docs/guide/relationships/retrieving-relationships.md
+++ b/docs/guide/relationships/retrieving-relationships.md
@@ -170,69 +170,50 @@ const user = store.getters['entities/users/query']()
 */
 ```
 
-## Relation Constraint
+## Relation Constraints
 
-To filter the result of relation loaded with `with` method, you can do so by passing a closure to the second argument.
+To filter the result of relation loaded by `with` method, you can pass a closure to the second argument to define additional constraints to the query.
 
 ```js
+// Get all users with posts that have `published` field value of `true`.
 const user = store.getters['entities/users/query']().with('posts', (query) => {
   query.where('published', true)
-}).find(1)
+}).get()
 
 /*
-  User {
-    id: 1,
-    name: 'john',
+  [
+    User {
+      id: 1,
+      name: 'john',
+      posts: [
+        Post: { id: 1, user_id: 1, body: '...', published: true },
+        Post: { id: 2, user_id: 1, body: '...', published: true }
+      ]
+    },
 
-    posts: [
-      Post: { id: 1, user_id: 1, body: '...', published: true },
-      Post: { id: 2, user_id: 1, body: '...', published: true }
-    ]
-  }
+    ...
+  ]
 */
 ```
 
-When you want to add a constraint to the nested relation, use a closure instead of the dot syntax.
+When you add constraints to the "nested" relation, the constraints will be applied to the deepest relationship.
 
 ```js
-const user = store.getters['entities/users/query']().with('posts', (query) => {
+const user = store.getters['entities/users/query']().with('posts.comments', (query) => {
+  // This constraint will be applied to the `comments`, not `posts`.
+  query.where('type', 'review')
+}).get()
+*/
+```
+
+If you need to add constraints to each relations, you could always nest constraints. This is the most flexible way of defining constraints to the relationships.
+
+```js
+const user = store.getters['entities/users/query']().with('posts.comments', (query) => {
   query.with('comments', (query) => {
     query.where('type', 'review')
   }).where('published', true)
-}).find(1)
-
-/*
-  User {
-    id: 1,
-    name: 'john',
-
-    posts: [
-      Post: {
-        id: 1,
-        user_id: 1,
-        body: '...',
-        published: true,
-
-        comments: [
-          Comment: { id: 1, post_id: 1, body: '...', type: 'review' },
-          Comment: { id: 2, post_id: 1, body: '...', type: 'review' }
-        ]
-      },
-
-      Post: {
-        id: 2,
-        user_id: 1,
-        body: '...',
-        published: true,
-
-        comments: [
-          Comment: { id: 3, post_id: 2, body: '...', type: 'review' },
-          Comment: { id: 4, post_id: 2, body: '...', type: 'review' }
-        ]
-      },
-    ]
-  }
-*/
+}).get()
 ```
 
 ## Querying Relationship Existence

--- a/test/feature/relations/Retrieve_With_NestedConstraints.spec.js
+++ b/test/feature/relations/Retrieve_With_NestedConstraints.spec.js
@@ -1,0 +1,62 @@
+import { createStore } from 'test/support/Helpers'
+import Model from 'app/model/Model'
+
+describe('Feature – Relations – With – Nested Constraints', () => {
+  it('can apply `with` constraints to nested relationships', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          posts: this.hasMany(Post, 'user_id')
+        }
+      }
+    }
+
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          user_id: this.attr(null),
+          comments: this.hasMany(Comment, 'post_id')
+        }
+      }
+    }
+
+    class Comment extends Model {
+      static entity = 'comments'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          title: this.attr(''),
+          post_id: this.attr(null)
+        }
+      }
+    }
+
+    const store = createStore([{ model: User }, { model: Post }, { model: Comment }])
+
+    User.create({ data: { id: 1 } })
+
+    Post.create({ data: { id: 1, user_id: 1, } })
+
+    Comment.create({ data: [
+      { id: 1, post_id: 1, title: 'Title01' },
+      { id: 2, post_id: 1, title: 'Title01' },
+      { id: 3, post_id: 1, title: 'Title02' }
+    ]})
+
+    const user = User.query().with('posts.comments', (query) => {
+      query.where('title', 'Title01')
+    }).find(1)
+
+    expect(user.posts.length).toBe(1)
+    expect(user.posts[0].comments.length).toBe(2)
+    expect(user.posts[0].comments[0].title).toBe('Title01')
+    expect(user.posts[0].comments[0].title).toBe('Title01')
+  })
+})


### PR DESCRIPTION
Issue #104

This PR will add ability for the `with` relationship to be able to define constraints to the nested relations. It also works for when you define multiple constraint by chaining `with` method many times.

```js
// This is going to work now.
const users = store.getters['entities/users']().
  .with('posts.comments', query => { ... })
  .with('posts.likes', query => { ... })
  .get()
```