### PR TITLE
updated Guide > Plugins section with the current list of components

### DIFF
--- a/docs/guide/digging-deeper/plugins.md
+++ b/docs/guide/digging-deeper/plugins.md
@@ -57,11 +57,11 @@ Following components are included within `components` argument.
 - MorphMany
 - MorphToMany
 - MorphedByMany
-- rootGetters
-- subGetters
-- rootActions
-- subActions
-- mutations
+- RootGetters
+- Getters
+- RootActions
+- Actions
+- RootMutations
 
 ## Using a Plugin
 


### PR DESCRIPTION
I noticed (thx @phortx) that the Guide doesn't reflect the recent changes in names for the components available in the ``install`` method of a plugin. Submitting a PR.