### PR TITLE
#216 Fix error when trying to insert morph many relation with value of null

### DIFF
--- a/src/attributes/relations/MorphMany.ts
+++ b/src/attributes/relations/MorphMany.ts
@@ -51,6 +51,10 @@ export default class MorphMany extends Relation {
    * Attach the relational key to the given data.
    */
   attach (key: any, record: Record, data: NormalizedData): void {
+    if (!Array.isArray(key)) {
+      return
+    }
+
     const relatedItems = data[this.related.entity]
 
     key.forEach((id: any) => {

--- a/test/feature/relations/MorphMany.spec.js
+++ b/test/feature/relations/MorphMany.spec.js
@@ -1,7 +1,48 @@
-import { createStore } from 'test/support/Helpers'
+import { createStore, createState } from 'test/support/Helpers'
 import Model from 'app/model/Model'
 
 describe('Features – Relations – Morph Many', () => {
+  it('can create morph many relation with value of null', async () => {
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          comments: this.morphMany(Comment, 'commentable_id', 'commentable_type')
+        }
+      }
+    }
+
+    class Comment extends Model {
+      static entity = 'comments'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          body: this.attr(''),
+          commentable_id: this.attr(null),
+          commentable_type: this.attr(null)
+        }
+      }
+    }
+
+    const store = createStore([{ model: Post }, { model: Comment }])
+
+    await store.dispatch('entities/posts/create', {
+      data: { id: 1, comments: null }
+    })
+
+    const expected = createState({
+      posts: {
+        '1': { $id: 1, id: 1, comments: [] }
+      },
+      comments: {}
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
   it('can resolve a morph many relation', async () => {
     class Post extends Model {
       static entity = 'posts'


### PR DESCRIPTION
Issue: #216

This PR fixs error when trying to insert morph many relation with value of null.