### PR TITLE
#240 Add hydrate method

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -44,6 +44,43 @@
   // 'entities/users/create'
   ```
 
+### hydrate
+
+- **`hydrate(record?: Record): Record`**
+
+  Fill any missing fields in the given record with the default value defined in the model schema. Note that the returned object is not Model instance, it's plain object.
+
+  ```js
+  User.hydrate({ id: 1 })
+
+  // { id: 1, name: 'Default Name' }
+  ```
+
+  If you pass relational data, those will be hydrated as well.
+
+  ```js
+  User.hydrate({
+    id: 1,
+    posts: [
+      { id: 1, user_id: 1 },
+      { id: 2, user_id: 1 }
+    ]
+  })
+
+  /*
+    {
+      id: 1,
+      name: 'Default Name',
+      posts: [
+        { id: 1, user_id: 1, title: 'Default Title' },
+        { id: 2, user_id: 1, title: 'Default Title' }
+      ]
+    }
+  */
+  ```
+
+  > **NOTE:** `hydrate` method will not "normalize" the given data. It will fill any missing field, but it wouldn't attach correct id value to the foreign field, for example adding `id` value of the user to the `user_id` field of the post, or increment the value specified by `increment` attribute.
+
 ## Instance Methods
 
 ### $store

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -453,22 +453,10 @@ export default class Model {
 
   /**
    * Fill any missing fields in the given record with the default value defined
-   * in the model schema. This method will ignore any "relationship" fields
-   * such as `hasMany` or `belongsTo` and return only non-relational fields.
+   * in the model schema.
    */
-  static hydrate (record: Record = {}): Record {
-    const fields = this.getFields()
-
-    return Object.keys(fields).reduce<Record>((newRecord, key) => {
-      const field = fields[key]
-      const value = record[key]
-
-      if (field instanceof Attributes.Type) {
-        newRecord[key] = field.make(value, record, key)
-      }
-
-      return newRecord
-    }, {})
+  static hydrate (record?: Record): Record {
+    return (new this(record)).$toJson()
   }
 
   /**

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -452,6 +452,26 @@ export default class Model {
   }
 
   /**
+   * Fill any missing fields in the given record with the default value defined
+   * in the model schema. This method will ignore any "relationship" fields
+   * such as `hasMany` or `belongsTo` and return only non-relational fields.
+   */
+  static hydrate (record: Record = {}): Record {
+    const fields = this.getFields()
+
+    return Object.keys(fields).reduce<Record>((newRecord, key) => {
+      const field = fields[key]
+      const value = record[key]
+
+      if (field instanceof Attributes.Type) {
+        newRecord[key] = field.make(value, record, key)
+      }
+
+      return newRecord
+    }, {})
+  }
+
+  /**
    * Get the constructor of this model.
    */
   $self (): typeof Model {

--- a/test/unit/model/Model.spec.js
+++ b/test/unit/model/Model.spec.js
@@ -173,6 +173,71 @@ describe('Unit – Model', () => {
     expect(() => { User.getAttributeClass('blah') }).toThrow()
   })
 
+  it('can hydrate given record', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('Default Doe')
+        }
+      }
+    }
+
+    const record = User.hydrate({ id: 1, age: 24 })
+
+    expect(record).toEqual({ id: 1, name: 'Default Doe' })
+  })
+
+  it('can hydrate without passing any record', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('Default Doe')
+        }
+      }
+    }
+
+    const record = User.hydrate()
+
+    expect(record).toEqual({ id: null, name: 'Default Doe' })
+  })
+
+  it('ignores any relationship records when hydrating a record', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          posts: this.hasMany(Post, 'user_id')
+        }
+      }
+    }
+
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          user_id: this.attr(null)
+        }
+      }
+    }
+
+    const record = User.hydrate({
+      id: 1,
+      posts: [{ id: 1 }, { id: 2 }]
+    })
+
+    expect(record).toEqual({ id: 1 })
+  })
+
   it('can serialize own fields into json', () => {
     class User extends Model {
       static entity = 'users'

--- a/test/unit/model/Model.spec.js
+++ b/test/unit/model/Model.spec.js
@@ -207,14 +207,27 @@ describe('Unit – Model', () => {
     expect(record).toEqual({ id: null, name: 'Default Doe' })
   })
 
-  it('ignores any relationship records when hydrating a record', () => {
+  it('can hydrate relationship data', () => {
     class User extends Model {
       static entity = 'users'
 
       static fields () {
         return {
           id: this.attr(null),
+          phone: this.hasOne(Phone, 'user_id'),
           posts: this.hasMany(Post, 'user_id')
+        }
+      }
+    }
+
+    class Phone extends Model {
+      static entity = 'phones'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          user_id: this.attr(null),
+          number: this.attr('12-3456-7891')
         }
       }
     }
@@ -225,17 +238,28 @@ describe('Unit – Model', () => {
       static fields () {
         return {
           id: this.attr(null),
-          user_id: this.attr(null)
+          user_id: this.attr(null),
+          title: this.attr('Default Title')
         }
       }
     }
 
     const record = User.hydrate({
       id: 1,
-      posts: [{ id: 1 }, { id: 2 }]
+      phone: { id: 1 },
+      posts: [{ id: 1, title: 'Title 001' }, { id: 2 }]
     })
 
-    expect(record).toEqual({ id: 1 })
+    const expected = {
+      id: 1,
+      phone: { id: 1, user_id: null, number: '12-3456-7891' },
+      posts: [
+        { id: 1, user_id: null, title: 'Title 001' },
+        { id: 2, user_id: null, title: 'Default Title' }
+      ]
+    }
+
+    expect(record).toEqual(expected)
   })
 
   it('can serialize own fields into json', () => {


### PR DESCRIPTION
Issue: #240

This PR adds `hydrate` method to Model. Which will fill any missing fields in the given record with the default value defined in the model schema. This method will ignore any "relationship" fields such as `hasMany` or `belongsTo` and return only non-relational fields.

@okatsuralau Is this spec good enough for you? (please take a look at test cases).


#### TODO

- [x] Add documentation.