### PR TITLE
Updated lifecycle hook examples in the docs

### DIFF
--- a/docs/guide/advanced/lifecycle-hooks.md
+++ b/docs/guide/advanced/lifecycle-hooks.md
@@ -30,11 +30,11 @@ class User extends Model {
     /* ... */
   }
 
-  beforeCreate (model) {
+  static beforeCreate (model) {
     // Do domething.
   }
 
-  afterDelete (model) {
+  static afterDelete (model) {
     // Do domething.
   }
 }
@@ -61,7 +61,7 @@ class User extends Model {
     /* ... */
   }
 
-  beforeSelect (users) {
+  static beforeSelect (users) {
     return users.filter(user => user.admin !== 'admin')
   }
 }


### PR DESCRIPTION
The examples of lifecycle hook usage in the docs did not previously declare the model hook handlers as static methods.