### PR TITLE
morphToMany relation duplicates the pivot records

### DIFF
--- a/src/attributes/relations/MorphToMany.ts
+++ b/src/attributes/relations/MorphToMany.ts
@@ -153,13 +153,18 @@ export default class MorphToMany extends Relation {
    */
   createPivots (parent: typeof Model, data: NormalizedData, key: string): NormalizedData {
     Utils.forOwn(data[parent.entity], (record) => {
-      const related = record[key]
+      const relatedIds = parent.query().newQuery(this.pivot.entity)
+                                       .where(this.id, record[this.parentKey])
+                                       .where(this.type, parent.entity)
+                                       .get()
+                                       .map(pivotRecord => pivotRecord[this.parentKey])
+      const relateds = (record[key] || []).filter((relatedId: any) => !relatedIds.includes(relatedId))
 
-      if (!Array.isArray(related) || related.length === 0) {
+      if (!Array.isArray(relateds) || relateds.length === 0) {
         return
       }
 
-      this.createPivotRecord(parent, data, record, related)
+      this.createPivotRecord(parent, data, record, relateds)
     })
 
     return data
@@ -172,15 +177,6 @@ export default class MorphToMany extends Relation {
     related.forEach((id) => {
       const parentId = record[this.parentKey]
       const pivotKey = `${parentId}_${id}_${parent.entity}`
-
-      const query = parent.query().newQuery(this.pivot.entity)
-                                  .where(this.relatedId, id)
-                                  .where(this.id, parentId)
-                                  .where(this.type, parent.entity)
-
-      if (query.count() > 0) {
-        return
-      }
 
       data[this.pivot.entity] = {
         ...data[this.pivot.entity],

--- a/src/attributes/relations/MorphToMany.ts
+++ b/src/attributes/relations/MorphToMany.ts
@@ -173,6 +173,15 @@ export default class MorphToMany extends Relation {
       const parentId = record[this.parentKey]
       const pivotKey = `${parentId}_${id}_${parent.entity}`
 
+      const query = parent.query().newQuery(this.pivot.entity)
+                                  .where(this.relatedId, id)
+                                  .where(this.id, parentId)
+                                  .where(this.type, parent.entity)
+
+      if (query.count() > 0) {
+        return
+      }
+
       data[this.pivot.entity] = {
         ...data[this.pivot.entity],
 

--- a/test/feature/relations/MorphToMany_Persist.spec.js
+++ b/test/feature/relations/MorphToMany_Persist.spec.js
@@ -207,4 +207,61 @@ describe('Features – Relations – Morph To Many – Persist', () => {
     expect(post.tags[0]).toBeInstanceOf(Tag)
     expect(post.tags[1]).toBeInstanceOf(Tag)
   })
+
+  it('can insert or update records', async () => {
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.increment(),
+          tags: this.morphToMany(Tag, Taggable, 'tag_id', 'taggable_id', 'taggable_type')
+        }
+      }
+    }
+
+    class Tag extends Model {
+      static entity = 'tags'
+
+      static fields () {
+        return {
+          id: this.increment(),
+          name: this.string('')
+        }
+      }
+    }
+
+    class Taggable extends Model {
+      static entity = 'taggables'
+
+      static fields () {
+        return {
+          id: this.increment(),
+          tag_id: this.number(0),
+          taggable_id: this.number(0),
+          taggable_type: this.string('')
+        }
+      }
+    }
+
+    createStore([{ model: Post }, { model: Tag }, { model: Taggable }])
+
+    const data = {
+      id: 1,
+      tags: [
+        { id: 1, name: 'news' },
+        { id: 2, name: 'cast' }
+      ]
+    }
+
+    await Post.insertOrUpdate({ data: [data] })
+    await Post.insertOrUpdate({ data: [data] })
+
+    const post = Post.query().with('tags').find(1)
+
+    expect(post).toBeInstanceOf(Post)
+    expect(post.tags.length).toBe(2)
+    expect(post.tags[0]).toBeInstanceOf(Tag)
+    expect(post.tags[1]).toBeInstanceOf(Tag)
+  })
 })


### PR DESCRIPTION
fix: https://github.com/vuex-orm/vuex-orm/issues/258

Hi @kiaking 

Cause is this.increment() to Taggable's id field, but I don't know is need to fix this problem, because pivot data isn't set to insertOrUpdate.
