### PR TITLE
#255 Add toJSON method to fix Nuxt `non-POJO` warning

### DIFF
--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -710,4 +710,15 @@ export default class Model {
       return item
     })
   }
+
+  /**
+   * This method is used by Nuxt server-side rendering. It will prevent
+   * `non-POJO` warning when using Vuex ORM with Nuxt universal mode.
+   * The method is not meant to be used publicly by a user.
+   *
+   * See https://github.com/vuex-orm/vuex-orm/issues/255 for more detail.
+   */
+  toJSON (): Record {
+    return this.$toJson()
+  }
 }

--- a/test/unit/model/Model.spec.js
+++ b/test/unit/model/Model.spec.js
@@ -364,4 +364,24 @@ describe('Unit – Model', () => {
     expect(json).not.toBeInstanceOf(User)
     expect(json).toEqual({ id: 1, array: [1, 2] })
   })
+
+  it('can serialize own fields into json via `toJSON` method', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          name: this.attr('')
+        }
+      }
+    }
+
+    const user = new User({ $id: 1, id: 1, name: 'John Doe' })
+
+    const json = user.toJSON()
+
+    expect(json).not.toBeInstanceOf(User)
+    expect(json).toEqual({ id: 1, name: 'John Doe' })
+  })
 })


### PR DESCRIPTION
Issue #255

This PR will fix `non-POJP` warning when using Vuex ORM with Nuxt universal mode. See the issue for more details.