### PR TITLE
Invalid class in inserting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ const posts = [
   }
 ]
 
-User.insert({ data: posts })
+Post.insert({ data: posts })
 
 // Or...
 


### PR DESCRIPTION
The inserting example uses `User.insert()` to insert the `posts` data. I think this is invalid. I had to change it to `Post.insert()` to make it work.