### PR TITLE
Adding array handling for query.with

### DIFF
--- a/docs/guide/relationships/retrieving-relationships.md
+++ b/docs/guide/relationships/retrieving-relationships.md
@@ -68,11 +68,21 @@ const user = User.query()
 */
 ```
 
-You can load multiple sub relations by separating them with `|`;
+You can load multiple sub relations by separating them with `|` (symbolizing the `or` syntax):
 
 ```js
 const user = User.query()
+  // Fetching all comments & reviews from user.posts
   .with('posts.comments|reviews')
+  .find(1)
+```
+
+Or passing an array of relations (in that case, the full path is needed):
+
+```js
+const user = User.query()
+  // Fetching all comments & reviews from user.posts + user.profile
+  .with(['posts.comments', 'posts.reviews', 'profile'])
   .find(1)
 ```
 

--- a/src/query/loaders/Loader.ts
+++ b/src/query/loaders/Loader.ts
@@ -7,7 +7,7 @@ export default class Loader {
   /**
    * Set the relationships that should be eager loaded with the query.
    */
-  static with (query: Query, name: string, constraint: Constraint | null): void {
+  static with (query: Query, name: string | string[], constraint: Constraint | null): void {
     // If the name of the relation is `*`, we'll load all relationships.
     if (name === '*') {
       this.withAll(query)
@@ -15,8 +15,13 @@ export default class Loader {
       return
     }
 
-    // Else parse relations and set appropriate constraints.
-    this.parseWithRelations(query, name.split('.'), constraint)
+    // If we passed an array, we dispatch the bits to with queries
+    if (name instanceof Array) {
+      name.forEach(relationName => this.with(query, relationName, constraint))
+    } else {
+      // Else parse relations and set appropriate constraints.
+      this.parseWithRelations(query, name.split('.'), constraint)
+    }
   }
 
   /**


### PR DESCRIPTION
Following suggestion on Slack, I added the possibility to pass an array of relations to the `query.with()` loader.