### PR TITLE
Adding a way to pass a closure as a default value

### DIFF
--- a/docs/guide/components/models.md
+++ b/docs/guide/components/models.md
@@ -113,14 +113,16 @@ There are several model attributes you can use to define model fields.
 
 ## Generic Type
 
-Use `this.attr()` method to define the most generic field. The argument is the default value of the field which will be used when creating a new data if the field is not present.
+Use `this.attr()` method to define the most generic field. The argument is the default value of the field which will be used when creating a new data if the field is not present.  
+Default value may be a closure creating a default value.
 
 ```js
 class User extends Model {
   static fields () {
     return {
       id: this.attr(null),
-      name: this.attr('John Doe')
+      name: this.attr('John Doe'),
+      rand: this.attr(() => Math.random())
     }
   }
 }

--- a/src/attributes/types/Attr.ts
+++ b/src/attributes/types/Attr.ts
@@ -20,6 +20,12 @@ export default class Attr extends Type {
   make (value: any, _parent: Record, key: string): any {
     value = value !== undefined ? value : this.value
 
-    return this.mutate(value, key)
+    // Default Value might be a function (taking no parameter)
+    let localValue = value;
+    if (typeof value === 'function') {
+      localValue = value();
+    }
+
+    return this.mutate(localValue, key)
   }
 }

--- a/test/unit/model/Model.spec.js
+++ b/test/unit/model/Model.spec.js
@@ -27,6 +27,26 @@ describe('Unit – Model', () => {
     expect(user.email).toBe('john@example.com')
   })
 
+  it('should set default field values using a closure', () => {
+    let counter = 0;
+
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(() => counter++)
+        }
+      }
+    }
+
+    const user = new User()
+    const user2 = new User()
+
+    expect(user.id).toBe(0)
+    expect(user2.id).toBe(1)
+  })
+
   it('should set given field values as a property on instanctiation', () => {
     class User extends Model {
       static entity = 'users'
@@ -44,7 +64,7 @@ describe('Unit – Model', () => {
     expect(user.name).toBe('Jane Doe')
     expect(user.email).toBe('john@example.com')
     expect(user.age).toBe(undefined)
-  })
+  }) 
 
   it('should mutate data if closure was given to the attr when instantiating', () => {
     class User extends Model {


### PR DESCRIPTION
`this.attr()` now accepts closure as a first argument to create default values