### PR TITLE
#304 Fix `toString` error when the primary key value is `null`

### DIFF
--- a/src/query/processors/IdFixer.ts
+++ b/src/query/processors/IdFixer.ts
@@ -23,9 +23,9 @@ export default class IdFixer {
     return Object.keys(records).reduce((newRecords, id) => {
       const record = records[id]
       const newId = query.model.id(record)
-      const newStringId = isNaN(newId) ? newId : newId.toString()
+      const newStringId = String(newId)
 
-      if (newId === undefined || id === newStringId) {
+      if (newId == null || id === newStringId) {
         newRecords[id] = record
 
         return newRecords

--- a/test/feature/basics/Insert.spec.js
+++ b/test/feature/basics/Insert.spec.js
@@ -1,4 +1,4 @@
-import { createStore } from 'test/support/Helpers'
+import { createStore, createState } from 'test/support/Helpers'
 import Model from 'app/model/Model'
 
 describe('Feature – Basics – Insert', () => {
@@ -36,5 +36,21 @@ describe('Feature – Basics – Insert', () => {
     })
 
     expect(store.state.entities.users.data).toEqual({})
+  })
+
+  it('can insert record with primary key value of `null`', async () => {
+    const store = createStore([{ model: User }])
+
+    await User.insert({
+      data: { id: null, name: 'John Doe' }
+    })
+
+    const expected = createState({
+      users: {
+        _no_key_1: { $id: '_no_key_1', id: null, name: 'John Doe' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
   })
 })


### PR DESCRIPTION
Issue #304

This PR fixes the `toString` error when trying to insert a record with primary key value of `null`.