### PR TITLE
#367 Fix where creating morph to many record with incremented id not working correctly

### DIFF
--- a/src/attributes/relations/MorphToMany.ts
+++ b/src/attributes/relations/MorphToMany.ts
@@ -177,6 +177,7 @@ export default class MorphToMany extends Relation {
   createPivotRecord (parent: typeof Model, data: NormalizedData, record: Record, related: any[]): void {
     related.forEach((id) => {
       const parentId = record[this.parentKey]
+      const relatedId = data[this.related.entity][id][this.relatedKey]
       const pivotKey = `${parentId}_${id}_${parent.entity}`
 
       data[this.pivot.entity] = {
@@ -184,7 +185,7 @@ export default class MorphToMany extends Relation {
 
         [pivotKey]: {
           $id: pivotKey,
-          [this.relatedId]: id,
+          [this.relatedId]: relatedId,
           [this.id]: parentId,
           [this.type]: parent.entity
         }

--- a/test/feature/relations/MorphToMany_Persist.spec.js
+++ b/test/feature/relations/MorphToMany_Persist.spec.js
@@ -287,6 +287,84 @@ describe('Features – Relations – Morph To Many – Persist', () => {
     expect(store.state.entities).toEqual(expected)
   })
 
+  it('can create a morph to many relation data with increment id set on all models', async () => {
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.increment(),
+          title: this.attr(''),
+          tags: this.morphToMany(Tag, Taggable, 'tag_id', 'taggable_id', 'taggable_type')
+        }
+      }
+    }
+
+    class Video extends Model {
+      static entity = 'videos'
+
+      static fields () {
+        return {
+          id: this.increment(),
+          tags: this.morphToMany(Tag, Taggable, 'tag_id', 'taggable_id', 'taggable_type')
+        }
+      }
+    }
+
+    class Tag extends Model {
+      static entity = 'tags'
+
+      static fields () {
+        return {
+          id: this.increment(),
+          name: this.attr('')
+        }
+      }
+    }
+
+    class Taggable extends Model {
+      static entity = 'taggables'
+
+      static fields () {
+        return {
+          id: this.increment(),
+          tag_id: this.attr(null),
+          taggable_id: this.attr(null),
+          taggable_type: this.attr(null)
+        }
+      }
+    }
+
+    const store = createStore([{ model: Post }, { model: Video }, { model: Tag }, { model: Taggable }])
+
+    await Post.create({
+      data: {
+        title: 'Post title.',
+        tags: [
+          { name: 'news' },
+          { name: 'cast' }
+        ]
+      }
+    })
+
+    const expected = createState({
+      posts: {
+        1: { $id: 1, id: 1, title: 'Post title.', tags: [] }
+      },
+      videos: {},
+      tags: {
+        1: { $id: 1, id: 1, name: 'news' },
+        2: { $id: 2, id: 2, name: 'cast' }
+      },
+      taggables: {
+        1: { $id: 1, id: 1, tag_id: 1, taggable_id: 1, taggable_type: 'posts' },
+        2: { $id: 2, id: 2, tag_id: 2, taggable_id: 1, taggable_type: 'posts' }
+      }
+    })
+
+    expect(store.state.entities).toEqual(expected)
+  })
+
   it('can resolve a morph to many relation', async () => {
     class Post extends Model {
       static entity = 'posts'


### PR DESCRIPTION
Issue #367

This PR fixes issue that wrong id value being generated when inserting records with morphToMany relationship with all models using `increment` attribute.