### PR TITLE
#319 Fix toJSON was not compatible with JSON.stringify

### DIFF
--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -780,7 +780,25 @@ export default class Model {
    *
    * See https://github.com/vuex-orm/vuex-orm/issues/255 for more detail.
    */
-  toJSON (): Record {
-    return this.$toJson()
+  toJSON (): object {
+    return Object.keys(this).reduce<object>((json, key) => {
+      const value = this[key]
+
+      if (value instanceof Model) {
+        json[key] = value.toJSON()
+
+        return json
+      }
+
+      if (Array.isArray(value)) {
+        json[key] = value.map(v => v instanceof Model ? v.toJSON() : v)
+
+        return json
+      }
+
+      json[key] = value
+
+      return json
+    }, {})
   }
 }

--- a/test/unit/model/Model_Utilities.spec.js
+++ b/test/unit/model/Model_Utilities.spec.js
@@ -121,6 +121,90 @@ describe('Unit – Model - Utilities', () => {
     const json = user.toJSON()
 
     expect(json).not.toBeInstanceOf(User)
-    expect(json).toEqual({ id: 1, name: 'John Doe' })
+    expect(json).toEqual({ $id: 1, id: 1, name: 'John Doe' })
+  })
+
+  it('can serialize nested fields into json via `toJSON` method', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          phone: this.hasOne(Phone, 'user_id'),
+          posts: this.hasMany(Post, 'user_id')
+        }
+      }
+    }
+
+    class Phone extends Model {
+      static entity = 'phones'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          user_id: this.attr(null)
+        }
+      }
+    }
+
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          user_id: this.attr(null)
+        }
+      }
+    }
+
+    const user = new User({
+      $id: 1,
+      id: 1,
+      phone: { $id: 2, id: 2, user_id: 1 },
+      posts: [
+        { $id: 3, id: 3, user_id: 1 },
+        { $id: 4, id: 4, user_id: 1 }
+      ]
+    })
+
+    const json = user.toJSON()
+
+    const expected = {
+      $id: 1,
+      id: 1,
+      phone: { $id: 2, id: 2, user_id: 1 },
+      posts: [
+        { $id: 3, id: 3, user_id: 1 },
+        { $id: 4, id: 4, user_id: 1 }
+      ]
+    }
+
+    expect(json).not.toBeInstanceOf(User)
+    expect(json.phone).not.toBeInstanceOf(Phone)
+    expect(json.posts[0]).not.toBeInstanceOf(Post)
+    expect(json.posts[1]).not.toBeInstanceOf(Post)
+    expect(json).toEqual(expected)
+  })
+
+  it('can serialize the array field via `toJSON` method', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          array: this.attr([])
+        }
+      }
+    }
+
+    const user = new User({ $id: 1, id: 1, array: [1, 2] })
+
+    const json = user.toJSON()
+
+    expect(json).not.toBeInstanceOf(User)
+    expect(json).toEqual({ $id: 1, id: 1, array: [1, 2] })
   })
 })


### PR DESCRIPTION
Issue #319 

This PR fixes where the current `toJSON` method is not compatible with `JSON.stringify`. The method is now going to return every property of the model instance (not only field that is defined in `static fields`).