### PR TITLE
#391 Fix hasManyBy relationship throwing error when trying to pass null at related field

### DIFF
--- a/src/attributes/relations/HasManyBy.ts
+++ b/src/attributes/relations/HasManyBy.ts
@@ -45,6 +45,10 @@ export default class HasManyBy extends Relation {
    * Attach the relational key to the given data.
    */
   attach (key: any, record: Record, _data: NormalizedData): void {
+    if (key === undefined || key === null) {
+      return
+    }
+
     if (key.length === 0) {
       return
     }

--- a/src/attributes/relations/HasManyBy.ts
+++ b/src/attributes/relations/HasManyBy.ts
@@ -53,10 +53,6 @@ export default class HasManyBy extends Relation {
       return
     }
 
-    if (record[this.foreignKey] !== undefined) {
-      return
-    }
-
     record[this.foreignKey] = key
   }
 


### PR DESCRIPTION
Issue #391

This PR fixes the error that hasManyBy relationship throwing error when trying to pass null at related field.