### PR TITLE
#504 Fix first and last method returning undefined on empty result

### DIFF
--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -307,16 +307,24 @@ export default class Query<T extends Model = Model> {
   first (): Data.Item<T> {
     const records = this.select()
 
-    return this.item(records[0]) // TODO: Delete "as ..." when model type coverage reaches 100%.
+    if (records.length === 0) {
+      return null
+    }
+
+    return this.item(this.hydrate(records[0]))
   }
 
   /**
-   * Returns the last single record of the query chain result.
+   * Returns the last record of the query chain result.
    */
   last (): Data.Item<T> {
     const records = this.select()
 
-    return this.item(records[records.length - 1]) // TODO: Delete "as ..." when model type coverage reaches 100%.
+    if (records.length === 0) {
+      return null
+    }
+
+    return this.item(this.hydrate(records[records.length - 1]))
   }
 
   /**

--- a/test/feature/basics/Retrieve.spec.js
+++ b/test/feature/basics/Retrieve.spec.js
@@ -122,32 +122,52 @@ describe('Feature – Retrieve', () => {
     expect(user).toEqual(expected)
   })
 
-  it('can retrieve the first item in the state', () => {
-    const store = createStore([{ model: User }])
+  describe('#first', () => {
+    it('can retrieve the first item from the store', async () => {
+      createStore([{ model: User }])
 
-    store.dispatch('entities/users/create', {
-      data: [{ id: 1 }, { id: 2 }]
+      await User.insert({
+        data: [{ id: 1 }, { id: 2 }]
+      })
+
+      const expected = { $id: '1', id: 1 }
+
+      const user = User.query().first()
+
+      expect(user).toEqual(expected)
     })
 
-    const expected = { $id: '1', id: 1 }
+    it('returns `null` if it can not find any record', () => {
+      createStore([{ model: User }])
 
-    const user = store.getters['entities/users/query']().first()
+      const user = User.query().first()
 
-    expect(user).toEqual(expected)
+      expect(user).toBe(null)
+    })
   })
 
-  it('can retrieve the last item in the state', () => {
-    const store = createStore([{ model: User }])
+  describe('#last', () => {
+    it('can retrieve the last item from the store', async () => {
+      createStore([{ model: User }])
 
-    store.dispatch('entities/users/create', {
-      data: [{ id: 1 }, { id: 2 }]
+      User.insert({
+        data: [{ id: 1 }, { id: 2 }]
+      })
+
+      const expected = { $id: '2', id: 2 }
+
+      const user = User.query().last()
+
+      expect(user).toEqual(expected)
     })
 
-    const expected = { $id: '2', id: 2 }
+    it('returns `null` if it can not find any record', () => {
+      createStore([{ model: User }])
 
-    const user = store.getters['entities/users/query']().last()
+      const user = User.query().last()
 
-    expect(user).toEqual(expected)
+      expect(user).toBe(null)
+    })
   })
 
   it('returns null when single item can not be found', () => {


### PR DESCRIPTION
Issue #504

This PR fixes where the `first` and the `last` method returning `undefined` when data is empty. It should return `null`, and it will now.