### PR TITLE
register model at runtime

### DIFF
--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -142,7 +142,7 @@ export default class Database {
    */
   private createSchema (): void {
     this.entities.forEach((entity) => {
-      this.schemas[entity.name] = Schema.create(entity.model)
+      this.registerSchema(entity)
     })
   }
 

--- a/src/modules/builder/Builder.ts
+++ b/src/modules/builder/Builder.ts
@@ -4,7 +4,6 @@ import Models from '../../database/Models'
 import Modules from '../../database/Modules'
 import Module from '../contracts/Module'
 import State from '../contracts/State'
-import RootState from '../contracts/RootState'
 import Getters from '../Getters'
 import RootGetters from '../RootGetters'
 import Actions from '../Actions'
@@ -41,10 +40,6 @@ export default class Builder {
 
       tree.modules[name].state = this.createState(namespace, name, model, module)
 
-      tree.getters[name] = (_state: RootState, getters: any, _rootState: any, _rootGetters: any) => () => {
-        return getters.query(name)
-      }
-
       tree.modules[name].getters = { ...Getters, ...module.getters }
 
       tree.modules[name].actions = { ...Actions, ...module.actions }
@@ -64,8 +59,6 @@ export default class Builder {
       namespaced: true,
 
       state: this.createState(namespace, name, model, module),
-
-      // TODO SZM no idea how to implement tree.getters[name]
 
       getters: { ...Getters, ...module.getters },
 

--- a/src/modules/builder/Builder.ts
+++ b/src/modules/builder/Builder.ts
@@ -33,18 +33,7 @@ export default class Builder {
    */
   static createModules (tree: Module, namespace: string, models: Models, modules: Modules): Module {
     Object.keys(modules).forEach((name) => {
-      const model = models[name]
-      const module = modules[name]
-
-      tree.modules[name] = { namespaced: true }
-
-      tree.modules[name].state = this.createState(namespace, name, model, module)
-
-      tree.modules[name].getters = { ...Getters, ...module.getters }
-
-      tree.modules[name].actions = { ...Actions, ...module.actions }
-
-      tree.modules[name].mutations = module.mutations || {}
+      tree.modules[name] = this.createModule(name, namespace, models[name], modules[name])
     })
 
     return tree

--- a/src/modules/builder/Builder.ts
+++ b/src/modules/builder/Builder.ts
@@ -56,6 +56,26 @@ export default class Builder {
   }
 
   /**
+   * Creates a new module to be registered under top level module
+   * from the given entity
+   */
+  static createModule (name: string, namespace: string, model: typeof Model, module: Vuex.Module<State, any>): Vuex.Module<State, any> {
+    return {
+      namespaced: true,
+
+      state: this.createState(namespace, name, model, module),
+
+      // TODO SZM no idea how to implement tree.getters[name]
+
+      getters: { ...Getters, ...module.getters },
+
+      actions: { ...Actions, ...module.actions },
+
+      mutations: module.mutations || {}
+    }
+  }
+
+  /**
    * Get new state to be registered to the modules.
    */
   static createState (namespace: string, name: string, model: typeof Model, module: Vuex.Module<State, any>): State {

--- a/test/feature/basics/Update.spec.js
+++ b/test/feature/basics/Update.spec.js
@@ -83,7 +83,7 @@ describe('Feature – Basics – Update', () => {
 
     store.dispatch('entities/users/update', { key_1: 1, key_2: 2, age: 24 })
 
-    const user = store.getters['entities/users']().where('key_1', 1).where('key_2', 2).first()
+    const user = store.getters['entities/users/query']().where('key_1', 1).where('key_2', 2).first()
 
     expect(user.name).toBe('John Doe')
     expect(user.age).toBe(24)

--- a/test/feature/database/RegisterModel.spec.js
+++ b/test/feature/database/RegisterModel.spec.js
@@ -18,6 +18,29 @@ describe('Feature – Database - Register Model', () => {
     }
   }
 
+  const userModule = {
+    state: {
+      currentId: null
+    },
+    getters: {
+      current: state => () => state.data[state.currentId]
+    },
+    mutations: {
+      setCurrent (state, id) {
+        state.currentId = id
+      }
+    },
+    actions: {
+      login ({ commit, state }, name) {
+        const id = Object.keys(state.data).find(key => state.data[key].name === name)
+        commit('setCurrent', id)
+      },
+      logout ({ commit }) {
+        commit('setCurrent', null)
+      }
+    }
+  }
+
   class Hobby extends Model {
     static entity = 'hobbies'
 
@@ -35,7 +58,7 @@ describe('Feature – Database - Register Model', () => {
     const database = new Database()
 
     database.register(User)
-    database.register(Hobby) // TODO custom module?
+    database.register(Hobby)
 
     const store = new Vuex.Store({
       plugins: [VuexORM.install(database)],
@@ -57,6 +80,34 @@ describe('Feature – Database - Register Model', () => {
     expect(hobby.name).toEqual('my hobby')
     expect(hobby.user.name).toEqual('my name')
     expect(user.name).toEqual('my name')
+  })
+
+  it('can register modules before being installed to vuex.', async () => {
+    const database = new Database()
+
+    database.register(User, userModule)
+
+    const store = new Vuex.Store({
+      plugins: [VuexORM.install(database)],
+      strict: true
+    })
+
+    await store.dispatch('entities/users/create', {
+      data: [
+        { name: 'user 1' },
+        { name: 'user 2' },
+        { name: 'user 3' }
+      ]
+    })
+
+    const user = store.getters['entities/users/query']().where('name', 'user 2').first()
+    const getCurrentUser = store.getters['entities/users/current']
+
+    expect(getCurrentUser()).toBeUndefined()
+    store.dispatch('entities/users/login', 'user 2')
+    expect(getCurrentUser()).toEqual(user)
+    store.dispatch('entities/users/logout')
+    expect(getCurrentUser()).toBeUndefined()
   })
 
   it('can register models after being installed to vuex.', async () => {
@@ -86,6 +137,35 @@ describe('Feature – Database - Register Model', () => {
     expect(hobby.name).toEqual('my hobby')
     expect(hobby.user.name).toEqual('my name')
     expect(user.name).toEqual('my name')
+  })
+
+  it('can register modules after being installed to vuex.', async () => {
+    const database = new Database()
+
+    const store = new Vuex.Store({
+      plugins: [VuexORM.install(database)],
+      strict: true
+    })
+
+    database.register(User, userModule)
+
+
+    await store.dispatch('entities/users/create', {
+      data: [
+        { name: 'user 1' },
+        { name: 'user 2' },
+        { name: 'user 3' }
+      ]
+    })
+
+    const user = store.getters['entities/users/query']().where('name', 'user 2').first()
+    const getCurrentUser = store.getters['entities/users/current']
+
+    expect(getCurrentUser()).toBeUndefined()
+    store.dispatch('entities/users/login', 'user 2')
+    expect(getCurrentUser()).toEqual(user)
+    store.dispatch('entities/users/logout')
+    expect(getCurrentUser()).toBeUndefined()
   })
 
   it('preserves state of previously registered models', async () => {

--- a/test/feature/database/RegisterModel.spec.js
+++ b/test/feature/database/RegisterModel.spec.js
@@ -1,0 +1,109 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+import VuexORM from 'app/index'
+import Database from 'app/database/Database'
+import Model from 'app/model/Model'
+
+Vue.use(Vuex)
+
+describe('Feature – Database - Register Model', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static fields () {
+      return {
+        id: this.increment(),
+        name: this.string()
+      }
+    }
+  }
+
+  class Hobby extends Model {
+    static entity = 'hobbies'
+
+    static fields () {
+      return {
+        id: this.increment(),
+        name: this.string(),
+        userId: this.attr(),
+        user: this.belongsTo(User, 'userId')
+      }
+    }
+  }
+
+  it('can register models before being installed to vuex.', async () => {
+    const database = new Database()
+
+    database.register(User)
+    database.register(Hobby) // TODO custom module?
+
+    const store = new Vuex.Store({
+      plugins: [VuexORM.install(database)],
+      strict: true
+    })
+
+    await store.dispatch('entities/hobbies/create', {
+      data: {
+        name: 'my hobby',
+        user: {
+          name: 'my name'
+        }
+      }
+    })
+
+    const hobby = store.getters['entities/hobbies/query']().with('user').first()
+    const user = store.getters['entities/users/query']().first()
+
+    expect(hobby.name).toEqual('my hobby')
+    expect(hobby.user.name).toEqual('my name')
+    expect(user.name).toEqual('my name')
+  })
+
+  it('can register models after being installed to vuex.', async () => {
+    const database = new Database()
+
+    database.register(User)
+
+    const store = new Vuex.Store({
+      plugins: [VuexORM.install(database)],
+      strict: true
+    })
+
+    database.register(Hobby)
+
+    await store.dispatch('entities/hobbies/create', {
+      data: {
+        name: 'my hobby',
+        user: {
+          name: 'my name'
+        }
+      }
+    })
+
+    const hobby = store.getters['entities/hobbies/query']().with('user').first()
+    const user = store.getters['entities/users/query']().first()
+
+    expect(hobby.name).toEqual('my hobby')
+    expect(hobby.user.name).toEqual('my name')
+    expect(user.name).toEqual('my name')
+  })
+
+  it('preserves state of previously registered models', async () => {
+    const database = new Database()
+
+    database.register(User)
+
+    const store = new Vuex.Store({
+      plugins: [VuexORM.install(database)],
+      strict: true
+    })
+
+    await store.dispatch('entities/users/create', { data: { name: 'my name' } })
+
+    database.register(Hobby)
+
+    const user = store.getters['entities/users/query']().first()
+
+    expect(user.name).toEqual('my name')
+  })
+})

--- a/test/feature/database/RegisterModel.spec.js
+++ b/test/feature/database/RegisterModel.spec.js
@@ -4,16 +4,9 @@ import VuexORM from 'app/index'
 import Database from 'app/database/Database'
 import Model from 'app/model/Model'
 
-import RootGetters from 'app/modules/RootGetters'
-
 Vue.use(Vuex)
 
 describe('Feature – Database - Register Model', () => {
-  afterEach(() => { // TODO because app/modules/builder/Builder.ts#L44 modifies RootGetters in place
-    delete RootGetters.users
-    delete RootGetters.hobbies
-  })
-
   class User extends Model {
     static entity = 'users'
 
@@ -112,31 +105,5 @@ describe('Feature – Database - Register Model', () => {
     const user = store.getters['entities/users/query']().first()
 
     expect(user.name).toEqual('my name')
-  })
-
-  it('can register the getter "${namespace}/${name}".', async () => {
-    const database = new Database()
-
-    database.register(User)
-
-    const store = new Vuex.Store({
-      plugins: [VuexORM.install(database)],
-      strict: true
-    })
-
-    database.register(Hobby)
-
-    await store.dispatch('entities/hobbies/create', {
-      data: {
-        name: 'my hobby',
-        user: {
-          name: 'my name'
-        }
-      }
-    })
-
-    expect(store.getters['entities/users']().first().name).toEqual('my name')
-    expect(store.getters['entities/hobbies']().first().name).toEqual('my hobby')
-
   })
 })

--- a/test/feature/modules/SubGetters_DirectEntityCall.spec.js
+++ b/test/feature/modules/SubGetters_DirectEntityCall.spec.js
@@ -20,7 +20,7 @@ describe('Features – Sub Getters – Direct Entity Call', () => {
       data: { id: 1, name: 'John Doe' }
     })
 
-    const users = store.getters['entities/users']().get()
+    const users = store.getters['entities/users/query']().get()
 
     expect(users.length).toBe(1)
     expect(users[0]).toBeInstanceOf(User)


### PR DESCRIPTION
PR for #187 

90% done - stuck with remaining 10%...

I can register a brand new module into vuex (like `'entities/hobbies'`) but cannot add a new getter under an existing module (like the namespaced getter `'hobbies'` under the module `'entities'`).

See L44-L46 in `ModuleBuilder.createModules()`
https://github.com/vuex-orm/vuex-orm/blob/a48dea13b7e19351d415b7b9941d9bb934393927/src/modules/builder/Builder.ts#L35-L56

Any ideas?
@kiaking what are that gettters for? I don't remember having met them in the docs or during coding.