### PR TITLE
Remove deprecated functionality references from docs/tests

### DIFF
--- a/docs/api/container/container.md
+++ b/docs/api/container/container.md
@@ -10,9 +10,9 @@ The Container is the global object that holds Vuex Store instance. The only purp
 
 ### store
 
-- **`static store: Database`**
+- **`static store: Vuex.Store<any>`**
 
-  The store instance that Vuex ORM is beeing installed.
+  The store instance that Vuex ORM is being installed.
 
 ## Static Methods
 

--- a/docs/api/database/database.md
+++ b/docs/api/database/database.md
@@ -4,11 +4,11 @@ sidebarDepth: 2
 
 # Database
 
-Database is the object that holds all Models and Modules that registered to the Vuex ORM. It is also responsible for generating the whole database relational schema from registered models. This schema is used to "Normalize" data before persisting to the Vuex Store.
+The Database is the object that holds all Models and Modules that are registered to the Vuex ORM. It is also responsible for generating the whole database relational schema from registered models. This schema is used to "Normalize" data before persisting to the Vuex Store.
 
-When using Vuex ORM, you would probably never need to use Database class after it's registered to the Vuex Store. But for those who are curious, we'll describe why object such as Database exists in the first place.
+When using Vuex ORM, you will unlikely need to use the Database class after it's registered to the Vuex Store. But for those who are curious, we'll describe why the Database object exists in the first place.
 
-In Vuex ORM, any Model could have any relationships with other Models. To resolve those relationships, we need to store all Models somewhere so that a Model can reference each other. That's where Database comes in to play. You can get any registered Model like this.
+In Vuex ORM, any Model can have any type of relationship with other Models. To resolve those relationships, we need to store all Models somewhere so that a Model can reference each other. That's where the Database comes in to play. You can get any registered Model like this.
 
 ```js
 const database = new Database()
@@ -36,19 +36,19 @@ class User extends Model {
 }
 ```
 
-So, can't we just resolve relationship directly from the Model? Unfortunately no, we can't. The biggest reason is that Vuex ORM is built on top of Vuex, and Vuex ORM is calling Vuex Getters/Actions/Mutations to interact with Vuex Store. In fact, you can call Vuex Actions directly to create or fetch data.
+So, can't we just resolve relationship directly from the Model? Unfortunately no, we can't. The primary reason is that Vuex ORM is built on top of Vuex, and Vuex ORM is calling Vuex Getters/Actions/Mutations to interact with the Vuex Store. In fact, you can call Vuex Actions directly to create or fetch data.
 
-Vuex Module doesn't have access to Model. It must resolve the Model from the entity name, which is `string`. When a user calls actions like `store.dispatch('entities/users/insert', { ... })`, we must somehow get User Model by the namespace, which is `users` in `entities/users/insert`. Well, Vuex ORM actions are getting Models from the Database.
+Vuex Module doesn't have access to Model. It must resolve the Model from the entity name, which is a `string`. When a user calls actions like `store.dispatch('entities/users/insert', { ... })`, we must somehow get User Model by the namespace, which is `users` in `entities/users/insert`. Well, Vuex ORM actions are getting Models from the Database.
 
 Finally, the created Database instance is registered to the Vuex Store instance, then it's registered to the [Container](../container/container) so we have access to it from everywhere.
 
-You can access the database instance through store instance, or Container.
+You can access the database instance through the store instance, or Container.
 
 ```js
-// Through store instance.
+// Through the store instance.
 this.$store.$db()
 
-// Through container.
+// Through the Container object.
 import { Container } from '@vuex-orm/core'
 
 Container.store.$db()

--- a/docs/api/model/model.md
+++ b/docs/api/model/model.md
@@ -83,7 +83,7 @@ sidebarDepth: 2
   */
   ```
 
-  > **NOTE:** `hydrate` method will not "normalize" the given data. It will fill any missing field, but it wouldn't attach correct id value to the foreign field, for example adding `id` value of the user to the `user_id` field of the post, or increment the value specified by `increment` attribute.
+  > **NOTE:** `hydrate` method will not "normalize" the given data. It will fill any missing field, but it wouldn't attach correct id value to the foreign field, for example adding `id` value of the user to the `user_id` field of the post, or increment the value specified by the `uid` attribute.
 
 ## Instance Methods
 

--- a/docs/guide/data/deleting.md
+++ b/docs/guide/data/deleting.md
@@ -1,6 +1,6 @@
 # Deleting
 
-You can delete data from the store by calling the `delete` Method on the Model class. The first argument is the ID—primary key value—of the record you want to delete.
+You can delete data from the store by calling the `delete` method on the Model class. The first argument is the ID—primary key value—of the record you want to delete.
 
 ```vue
 <template>

--- a/docs/guide/data/inserting-and-updating.md
+++ b/docs/guide/data/inserting-and-updating.md
@@ -145,7 +145,7 @@ class User extends Model {
 
   static fields () {
     return {
-      id: this.increment(),
+      id: this.uid(),
       name: this.string('Default Name')
     }
   }
@@ -209,7 +209,7 @@ User.create({
 }
 ```
 
-Note that records should always be created with the primary key value provided. Leaving the primary key empty (`''`, `undefined` or `null`) will result in index keys `_no_key_X` and a high probability of inconsistent behavior. This also means that a primary key of type `increment` is recommended when using the `new` method. [See here](../model/defining-models.md#primary-key-and-index-key) to learn more about primary key and index key.
+Note that records should always be created with the primary key value provided. Leaving the primary key empty (`''`, `undefined` or `null`) will result in index keys `_no_key_X` and a high probability of inconsistent behavior. This also means that a primary key of type `uid` is recommended when using the `new` method. [See here](../model/defining-models.md#primary-key-and-index-key) to learn more about primary key and index key.
 
 ### Inserting Relationships
 

--- a/docs/guide/digging-deeper/plugins.md
+++ b/docs/guide/digging-deeper/plugins.md
@@ -47,7 +47,7 @@ The following components are included within the `components` argument.
 - String
 - Number
 - Boolean
-- Increment
+- Uid
 - Relation
 - HasOne
 - BelongsTo

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -109,6 +109,7 @@ export default class Model {
    * @deprecated Use `uid` attribute instead.
    */
   static increment (): Attributes.Uid {
+    console.warn('[Vuex ORM] Attribtue type `increment` has been deprecated and replaced by `uid`')
     return this.uid()
   }
 

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -109,6 +109,7 @@ export default class Model {
    * @deprecated Use `uid` attribute instead.
    */
   static increment (): Attributes.Uid {
+    /* istanbul ignore next */
     if (process.env.NODE_ENV !== 'production') {
       console.warn('[Vuex ORM] Attribute type `increment` has been deprecated and replaced with `uid`.')
     }

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -109,7 +109,7 @@ export default class Model {
    * @deprecated Use `uid` attribute instead.
    */
   static increment (): Attributes.Uid {
-    console.warn('[Vuex ORM] Attribtue type `increment` has been deprecated and replaced by `uid`')
+    console.warn('[Vuex ORM] Attribtue type `increment` has been deprecated and replaced with `uid`')
     return this.uid()
   }
 

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -109,7 +109,9 @@ export default class Model {
    * @deprecated Use `uid` attribute instead.
    */
   static increment (): Attributes.Uid {
-    console.warn('[Vuex ORM] Attribtue type `increment` has been deprecated and replaced with `uid`')
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[Vuex ORM] Attribute type `increment` has been deprecated and replaced with `uid`.')
+    }
     return this.uid()
   }
 

--- a/test/feature/basics/New.spec.js
+++ b/test/feature/basics/New.spec.js
@@ -7,7 +7,7 @@ describe('Feature – Basics – New', () => {
 
     static fields () {
       return {
-        id: this.increment(null),
+        id: this.uid(),
         name: this.attr('Default Doe')
       }
     }

--- a/test/feature/relations/MorphToMany_Persist.spec.js
+++ b/test/feature/relations/MorphToMany_Persist.spec.js
@@ -129,7 +129,7 @@ describe('Features – Relations – Morph To Many – Persist', () => {
     expect(store.state.entities.posts.data).toEqual(expected)
   })
 
-  it('can create a morph to many relation data with increment id set on pivot model', async () => {
+  it('can create a morph to many relation data with uid as id set on pivot model', async () => {
     class Post extends Model {
       static entity = 'posts'
 
@@ -205,13 +205,13 @@ describe('Features – Relations – Morph To Many – Persist', () => {
     expect(store.state.entities).toEqual(expected)
   })
 
-  it('can create a morph to many relation data with increment id set on parent model', async () => {
+  it('can create a morph to many relation data with uid as id set on parent model', async () => {
     class Post extends Model {
       static entity = 'posts'
 
       static fields () {
         return {
-          id: this.increment(),
+          id: this.uid(),
           title: this.attr(''),
           tags: this.morphToMany(Tag, Taggable, 'tag_id', 'taggable_id', 'taggable_type')
         }

--- a/test/unit/model/Model.spec.js
+++ b/test/unit/model/Model.spec.js
@@ -232,4 +232,23 @@ describe('Unit – Model', () => {
 
     expect(record).toEqual({ $id: null, id: null, name: 'Default Doe' })
   })
+
+  it('should warn user that increment is deprecated', () => {
+    const spy = jest.spyOn(global.console, 'warn').mockImplementation()
+
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.increment()
+        }
+      }
+    }
+
+    const user = new User()
+
+    expect(user.id).toBe('$uid1')
+    expect(spy).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
This PR attempts to dissipate the already deprecated `increment` attribute in the documentation and unit tests.

The attribute `increment` has been replaced by the newly promoted `uid` attribute and it makes sense to warn users who update to future releases.

There are various other grammatical and type corrections thrown in for good measure.