### PR TITLE
Incomprehensible exception thrown due to missing var `name`

### DIFF
--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -98,7 +98,8 @@ export default class Database {
   model <T extends typeof Model> (model: T): T
   model (model: string): typeof Model
   model (model: typeof Model | string): typeof Model | string {
-    const m = this.models()[typeof model === 'string' ? model : model.entity]
+    const name = typeof model === 'string' ? model : model.entity
+    const m = this.models()[name]
 
     if (!m) {
       throw new Error(
@@ -116,7 +117,8 @@ export default class Database {
   baseModel <T extends typeof Model> (model: T): T
   baseModel (model: string): typeof Model
   baseModel (model: typeof Model | string): typeof Model | string {
-    const m = this.baseModels()[typeof model === 'string' ? model : model.entity]
+    const name = typeof model === 'string' ? model : model.entity
+    const m = this.baseModels()[name]
 
     if (!m) {
       throw new Error(


### PR DESCRIPTION
This PR fixes an incomprehensible exception thrown when attempting to register a model that references an absent one (either it was not registered or doesn't exist) or context based retrieval.

Exception thrown:

```
[Vuex ORM] Could not find the model ``. Please check if you have registered the model to the database.
```

Previously it stated the suspect model entity but an undeclared variable in the error message prohibits this.

Model definition:
```
class User extends Model {
  static entity = 'users';
  static fields() {
    return {
      id: this.attr(null),
      role: this.hasOne('nonregistered')
    }
  }
}
```

Context based:
```
new Database().model('nonregistered')

$store.$db().model('nonregistered')
```
