### PR TITLE
Fix broken link to Normalizing State Shape article and composite primary key example

### DIFF
--- a/docs/guide/data/retrieving.md
+++ b/docs/guide/data/retrieving.md
@@ -61,7 +61,7 @@ If your model has a composite primary key, you can retrieve data by passing an a
 import { Model } from '@vuex-orm/core'
 
 class Subscription extends Model {
-  static entity = 'users'
+  static entity = 'subscription'
 
   static primaryKey = ['video_id', 'user_id']
 
@@ -78,7 +78,7 @@ Then, you can retrieve Subscription records as below. Remember that the value or
 
 ```js
 // Get a subscription with video_id 1 and user_id 2.
-const subscription = User.find([1, 2])
+const subscription = Subscription.find([1, 2])
 
 // { video_id: 1, user_id: 2 }
 ```

--- a/docs/guide/prologue/what-is-vuex-orm.md
+++ b/docs/guide/prologue/what-is-vuex-orm.md
@@ -6,7 +6,7 @@ Many applications deal with data that is nested or relational in nature. For exa
 
 To nicely handle such data, one approach is to split the nested data into separate modules and decouple them from each other. Simply put, it's kind of like treating a portion of your store as if it were a database, and keep that data in a normalized form.
 
-[This is an excellent article](http://redux.js.org/docs/recipes/reducers/NormalizingStateShape.html) that describes the difficulty of nested data structures. It also explains how to design normalized state, and Vuex ORM is heavily inspired by it.
+[This is an excellent article](https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape/) that describes the difficulty of nested data structures. It also explains how to design normalized state, and Vuex ORM is heavily inspired by it.
 
 Note that in this documentation, we're borrowing many examples and texts from the article. I would like to credit [Redux](https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape) and the author of the section [Mark Erikson](https://github.com/markerikson) for the beautiful piece of article.
 


### PR DESCRIPTION
Updating broken link to article: Redux Normalizing State Shape documentation.
From: http://redux.js.org/docs/recipes/reducers/NormalizingStateShape.html
To: https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape/