### PR TITLE
feat: add `as` method to customize `pivot` attribute name

### DIFF
--- a/docs/guide/data/inserting-and-updating.md
+++ b/docs/guide/data/inserting-and-updating.md
@@ -341,6 +341,120 @@ The insertion method works for all relationship types including complex ones suc
 
 Though there are few things that you should know about when inserting relationship in a slightly complex manner.
 
+### Inserting Many To Many Relationships
+
+When inserting many-to-many relationships, such as `belongsToMany` or `morphToMany`, any data nested under the `pivot` attribute will be inserted as well.
+
+Let's take a look at an example. Here we have `User` belonging to many `Role` through `RoleUser`.
+
+```js
+class User extends Model {
+  static entity = 'users'
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      roles: this.belongsToMany(Role, RoleUser, 'user_id', 'role_id')
+    }
+  }
+}
+
+class Role extends Model {
+  static entity = 'roles'
+
+  static fields () {
+    return {
+      id: this.attr(null)
+    }
+  }
+}
+
+class RoleUser extends Model {
+  static entity = 'role_user'
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      role_id: this.attr(null),
+      user_id: this.attr(null),
+      level: this.number(1)
+    }
+  }
+}
+```
+
+Having these structures, you may include intermediate data (`RoleUser` data) under `pivot` attribute.
+
+```js
+// Create user data with nested roles and its intermediate data.
+User.insert({
+  data: {
+    id: 1,
+    roles: [
+      {
+        id: 1,
+        pivot: { id: 1, level: 2 }
+      },
+      {
+        id: 2,
+        pivot: { id: 2, level: 3 }
+      }
+    ]
+  }
+})
+
+// State after `insert`.
+{
+  entities: {
+    users: {
+      1: { id: 1 }
+    },
+    roles: {
+      1: { id: 1 },
+      2: { id: 2 }
+    },
+    role_user: {
+      1: { id: 1, user_id: 1, role_id: 1, level: 2 },
+      2: { id: 2, user_id: 1, role_id: 2, level: 3 }
+    }
+  }
+}
+```
+
+Note that you may customize the name of `pivot` attributes by using the `as` method when defining the relationship.
+
+```js
+class User extends Model {
+  static entity = 'users'
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      roles: this.belongsToMany(
+        Role,
+        RoleUser,
+        'user_id',
+        'role_id'
+      ).as('permission')
+    }
+  }
+}
+```
+
+In this case, you must pass intermediate data to the key that matches the customized name.
+
+```js
+User.insert({
+  data: {
+    id: 1,
+    roles: [{
+      id: 1,
+      permission: { id: 1, level: 2 }
+    }]
+  }
+})
+```
+
 ### Generating Missing Foreign Keys
 
 If data is missing its foreign keys, Vuex ORM will automatically generate them during the inserting process. For example, let's say you have the following Model definition.
@@ -446,7 +560,7 @@ class RoleUser extends Model {
 }
 ```
 
-When inserting data, you insert User data its related Role data without RoleUser data. Still, in this case, Vuex ORM will generate required intermediate pivot records.
+When inserting data, you insert User data and its related Role data but without RoleUser data. Still, in this case, Vuex ORM will generate required intermediate pivot records.
 
 ```js
 // Insert User data with Role data.
@@ -472,14 +586,14 @@ User.insert({
       2: { id: 2, name: 'operator' }
     },
     role_user: {
-      1_1: { role_id: 1, user_id: 1 },
-      2_1: { role_id: 2, user_id: 1 }
+      '[1,1]': { role_id: 1, user_id: 1 },
+      '[2,1]': { role_id: 2, user_id: 1 }
     }
   }
 }
 ```
 
-Note that there is a caveat with "Has Many Through" relationship. When creating data that contains "Has Many Through" relationship without intermediate pivot records, the intermediate record will not be generated. Let's say you have the following model definitions.
+However, note that there is a caveat with "Has Many Through" relationship. When creating data that contains "Has Many Through" relationship without intermediate pivot records, the intermediate record will not be generated. Let's say you have the following model definitions.
 
 ```js
 class Country extends Model {
@@ -556,24 +670,6 @@ Vuex ORM will normalize the data and save them to the store as below.
 See there is no users record, and `user_id` at `posts` becomes empty. This happens because Vuex ORM wouldn't have any idea how post data relate to the intermediate User. Hence if you create data like this, you wouldn't be able to retrieve them by getters anymore. In such cases, it is recommended to create data with the intermediate records.
 
 ```js
-const data = {
-  id: 1,
-  users: [
-    {
-      id: 1,
-      posts: [
-        { id: 1 }
-      ]
-    },
-    {
-      id: 2,
-      posts: [
-        { id: 2 }
-      ]
-    }
-  ]
-}
-
 Country.create({
   data: {
     id: 1,

--- a/docs/guide/model/relationships.md
+++ b/docs/guide/model/relationships.md
@@ -270,9 +270,8 @@ class Cluster extends Model {
 ## Many To Many
 
 Many-to-many relations are slightly more complicated than other relationships. An example of such a relationship is a user with many roles, where the roles are also shared by other users. For example, many users may have the role of "Admin". To define this relationship, three models are needed: User, Role, and RoleUser.
-The RoleUser contains the fields to hold id of User and Role model. We'll define `user_id` and `role_id` fields here.
 
-The name of RoleUser model could be anything, but for this example, we'll keep it this way to make it easy to understand.
+The RoleUser contains the fields to hold id of User and Role model. We'll define `user_id` and `role_id` fields here. The name of RoleUser model could be anything, but for this example, we'll keep it this way to make it easy to understand.
 
 Many-to-many relationships are defined by defining `this.belongsToMany()`.
 
@@ -315,7 +314,7 @@ class RoleUser extends Model {
 The argument order of the `belongsToMany` attribute is:
 
 1. The Related model which is in this case Role.
-2. Intermediate pivot model which is RoleUser.
+2. Intermediate pivot model which is in this case RoleUser.
 3. Field of the pivot model that holds the id value of the parent – User – model.
 4. Field of the pivot model that holds the id value of the related – Role – model.
 
@@ -382,6 +381,54 @@ class RoleUser extends Model {
 ```
 
 As you can see, the relationship is defined the same as its User counterpart, except referencing the User model and the order of 3rd and 4th argument is inversed.
+
+### Access Intermediate Model
+
+Working with many-to-many relations requires the presence of an intermediate model. Vuex ORM provides some helpful ways of interacting with this model. For example, let's assume our `User` object has many `Role` objects that it is related to. After accessing this relationship, we may access the intermediate model using the `pivot` attribute on the models.
+
+```js
+const user = User.query().with('roles').first()
+
+user.roles.forEach((role) => {
+  console.log(role.pivot)
+})
+```
+
+Notice that each `Role` model we retrieve is automatically assigned a `pivot` attribute. This attribute contains a model representing the intermediate model and may be used like any other model.
+
+### Customizing The `pivot` Attribute Name
+
+As noted earlier, attributes from the intermediate model may be accessed on models using the `pivot` attribute. However, you are free to customize the name of this attribute to better reflect its purpose within your application.
+
+For example, if your application contains users that may subscribe to podcasts, you probably have a many-to-many relationship between users and podcasts. If this is the case, you may wish to rename your intermediate table accessor to `subscription` instead of `pivot`. This can be done using the `as` method when defining the relationship:
+
+```js
+class User extends Model {
+  static entity = 'users'
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      podcasts: this.belongsToMany(
+        Podcast,
+        Subscription,
+        'user_id',
+        'podcast_id'
+      ).as('subscription')
+    }
+  }
+}
+```
+
+Once this is done, you may access the intermediate table data using the customized name.
+
+```js
+const user = User.query().with('podcasts').first()
+
+user.podcasts.forEach((podcast) => {
+  console.log(podcast.subscription)
+})
+```
 
 ## Has Many Through
 
@@ -746,4 +793,51 @@ class Tag extends Model {
     }
   }
 }
+```
+
+### Access Intermediate Model
+
+As the same as `belongsToMany` relationship, you may access the intermediate model for polymorphic many-to-many relationship through `pivot` attribute on the model.
+
+```js
+const post = Post.query().with('tags').first()
+
+post.tags.forEach((tag) => {
+  console.log(tag.pivot)
+})
+```
+
+Each `Tag` model we retrieve is automatically assigned a `pivot` attribute. This attribute contains a model representing the intermediate model and may be used like any other model.
+
+### Customizing The `pivot` Attribute Name
+
+Again, as the same as `belongsToMany` relationship, you are free to customize the name of this attribute through `as` method.
+
+```js
+class Post extends Model {
+  static entity = 'posts'
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      tags: this.morphToMany(
+        Tag,
+        Taggable,
+        'tag_id',
+        'taggable_id',
+        'taggable_type'
+      ).as('intermediate')
+    }
+  }
+}
+```
+
+The `as` method is also available for `morphedByMany` relationship. Once this is done, you may access the intermediate table data using the customized name.
+
+```js
+const post = Post.query().with('tags').first()
+
+post.tags.forEach((tag) => {
+  console.log(tag.intermediate)
+})
 ```

--- a/src/attributes/relations/BelongsToMany.ts
+++ b/src/attributes/relations/BelongsToMany.ts
@@ -52,7 +52,7 @@ export default class BelongsToMany extends Relation {
   /**
    * The key name of the pivot data.
    */
-  pivotKey: string
+  pivotKey: string = 'pivot'
 
   /**
    * Create a new belongs to instance.
@@ -64,8 +64,7 @@ export default class BelongsToMany extends Relation {
     foreignPivotKey: string,
     relatedPivotKey: string,
     parentKey: string,
-    relatedKey: string,
-    pivotKey: string
+    relatedKey: string
   ) {
     super(model) /* istanbul ignore next */
 
@@ -75,7 +74,15 @@ export default class BelongsToMany extends Relation {
     this.relatedPivotKey = relatedPivotKey
     this.parentKey = parentKey
     this.relatedKey = relatedKey
-    this.pivotKey = pivotKey
+  }
+
+  /**
+   * Specify the custom pivot accessor to use for the relationship.
+   */
+  as (accessor: string): this {
+    this.pivotKey = accessor
+
+    return this
   }
 
   /**

--- a/src/attributes/relations/MorphToMany.ts
+++ b/src/attributes/relations/MorphToMany.ts
@@ -48,7 +48,7 @@ export default class MorphToMany extends Relation {
   /**
    * The key name of the pivot data.
    */
-  pivotKey: string
+  pivotKey: string = 'pivot'
 
   /**
    * Create a new belongs to instance.
@@ -61,8 +61,7 @@ export default class MorphToMany extends Relation {
     id: string,
     type: string,
     parentKey: string,
-    relatedKey: string,
-    pivotKey: string
+    relatedKey: string
   ) {
     super(model) /* istanbul ignore next */
 
@@ -73,7 +72,15 @@ export default class MorphToMany extends Relation {
     this.type = type
     this.parentKey = parentKey
     this.relatedKey = relatedKey
-    this.pivotKey = pivotKey
+  }
+
+  /**
+   * Specify the custom pivot accessor to use for the relationship.
+   */
+  as (accessor: string): this {
+    this.pivotKey = accessor
+
+    return this
   }
 
   /**

--- a/src/attributes/relations/MorphedByMany.ts
+++ b/src/attributes/relations/MorphedByMany.ts
@@ -48,7 +48,7 @@ export default class MorphedByMany extends Relation {
   /**
    * The key name of the pivot data.
    */
-  pivotKey: string
+  pivotKey: string = 'pivot'
 
   /**
    * Create a new belongs to instance.
@@ -61,8 +61,7 @@ export default class MorphedByMany extends Relation {
     id: string,
     type: string,
     parentKey: string,
-    relatedKey: string,
-    pivotKey: string
+    relatedKey: string
   ) {
     super(model) /* istanbul ignore next */
 
@@ -73,7 +72,15 @@ export default class MorphedByMany extends Relation {
     this.type = type
     this.parentKey = parentKey
     this.relatedKey = relatedKey
-    this.pivotKey = pivotKey
+  }
+
+  /**
+   * Specify the custom pivot accessor to use for the relationship.
+   */
+  as (accessor: string): this {
+    this.pivotKey = accessor
+
+    return this
   }
 
   /**

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -177,8 +177,7 @@ export default class Model {
     foreignPivotKey: string,
     relatedPivotKey: string,
     parentKey?: string,
-    relatedKey?: string,
-    pivotKey?: string
+    relatedKey?: string
   ): Attributes.BelongsToMany {
     return new Attributes.BelongsToMany(
       this,
@@ -187,8 +186,7 @@ export default class Model {
       foreignPivotKey,
       relatedPivotKey,
       this.localKey(parentKey),
-      this.relation(related).localKey(relatedKey),
-      this.pivotKey(pivotKey)
+      this.relation(related).localKey(relatedKey)
     )
   }
 
@@ -223,8 +221,7 @@ export default class Model {
     id: string,
     type: string,
     parentKey?: string,
-    relatedKey?: string,
-    pivotKey?: string
+    relatedKey?: string
   ): Attributes.MorphToMany {
     return new Attributes.MorphToMany(
       this,
@@ -234,8 +231,7 @@ export default class Model {
       id,
       type,
       this.localKey(parentKey),
-      this.relation(related).localKey(relatedKey),
-      this.pivotKey(pivotKey)
+      this.relation(related).localKey(relatedKey)
     )
   }
 
@@ -249,8 +245,7 @@ export default class Model {
     id: string,
     type: string,
     parentKey?: string,
-    relatedKey?: string,
-    pivotKey?: string
+    relatedKey?: string
   ): Attributes.MorphedByMany {
     return new Attributes.MorphedByMany(
       this,
@@ -260,8 +255,7 @@ export default class Model {
       id,
       type,
       this.localKey(parentKey),
-      this.relation(related).localKey(relatedKey),
-      this.pivotKey(pivotKey)
+      this.relation(related).localKey(relatedKey)
     )
   }
 
@@ -515,17 +509,6 @@ export default class Model {
     }
 
     return typeof this.primaryKey === 'string' ? this.primaryKey : 'id'
-  }
-
-  /**
-   * Get pivot key.
-   */
-  static pivotKey (key?: string): string {
-    if (key) {
-      return key
-    }
-
-    return 'pivot'
   }
 
   /**

--- a/test/feature/relations/BelongsToMany_Persist.spec.js
+++ b/test/feature/relations/BelongsToMany_Persist.spec.js
@@ -461,7 +461,7 @@ describe('Feature – Relations – Belongs To Many – Persist', () => {
       static fields () {
         return {
           id: this.attr(null),
-          permissions: this.belongsToMany(Role, RoleUser, 'user_id', 'role_id', 'id', 'id', 'role_user')
+          permissions: this.belongsToMany(Role, RoleUser, 'user_id', 'role_id').as('role_user')
         }
       }
     }

--- a/test/feature/relations/MorphToMany_Persist.spec.js
+++ b/test/feature/relations/MorphToMany_Persist.spec.js
@@ -293,7 +293,7 @@ describe('Features – Relations – Morph To Many – Persist', () => {
       static fields () {
         return {
           id: this.attr(null),
-          tags: this.morphToMany(Tag, Taggable, 'tag_id', 'taggable_id', 'taggable_type', 'id', 'id', 'tag_pivot')
+          tags: this.morphToMany(Tag, Taggable, 'tag_id', 'taggable_id', 'taggable_type').as('tag_pivot')
         }
       }
     }

--- a/test/feature/relations/MorphedByMany_Persist.spec.js
+++ b/test/feature/relations/MorphedByMany_Persist.spec.js
@@ -209,8 +209,8 @@ describe('Feature – Relations – Morphed By Many – Persist', () => {
         return {
           id: this.attr(null),
           name: this.attr(''),
-          posts: this.morphedByMany(Post, Taggable, 'tag_id', 'taggable_id', 'taggable_type', 'id', 'id', 'tag'),
-          videos: this.morphedByMany(Video, Taggable, 'tag_id', 'taggable_id', 'taggable_type', 'id', 'id', 'tag')
+          posts: this.morphedByMany(Post, Taggable, 'tag_id', 'taggable_id', 'taggable_type').as('tag'),
+          videos: this.morphedByMany(Video, Taggable, 'tag_id', 'taggable_id', 'taggable_type').as('tag')
         }
       }
     }


### PR DESCRIPTION
This PR is built on top of #542. It adds `as` method to many-to-many relationship attribute to let users customize `pivot` key name.

```js
class User extends Model {
  static entity = 'users'

  static fields () {
    return {
      id: this.attr(null),
      podcasts: this.belongsToMany(
        Podcast,
        Subscription,
        'user_id',
        'podcast_id'
      ).as('subscription')
    }
  }
}

const user = User.query().with('podcasts').first()

user.podcasts.forEach((podcast) => {
  console.log(podcast.subscription)
})
```

@cuebit Could you check mainly at the documentations whether it's easy to understand this feature? 😃 