### PR TITLE
fix: nested relationship orderBy constraints

### DIFF
--- a/src/attributes/relations/BelongsTo.ts
+++ b/src/attributes/relations/BelongsTo.ts
@@ -14,7 +14,7 @@ export default class BelongsTo extends Relation {
   parent: typeof Model
 
   /**
-   * The foregin key of the model.
+   * The foreign key of the model.
    */
   foreignKey: string
 

--- a/src/attributes/relations/BelongsToMany.ts
+++ b/src/attributes/relations/BelongsToMany.ts
@@ -148,16 +148,20 @@ export default class BelongsToMany extends Relation {
    * Create a new indexed map for the pivot relation.
    */
   mapPivotRelations (pivots: Collection, relatedQuery: Query): Records {
-    const relateds = this.mapManyRelations(relatedQuery.get(), this.relatedKey)
+    const relations = this.mapManyRelations(relatedQuery.get(), this.relatedKey)
 
-    return pivots.reduce((records, record) => {
+    if (relatedQuery.orders.length) {
+      return this.mapRelationsByOrders(pivots, relations, this.foreignPivotKey, this.relatedPivotKey)
+    }
+
+    return pivots.reduce<Record>((records, record) => {
       const id = record[this.foreignPivotKey]
 
       if (!records[id]) {
         records[id] = []
       }
 
-      const related = relateds[record[this.relatedPivotKey]]
+      const related = relations.get(record[this.relatedPivotKey])
 
       if (related) {
         records[id] = records[id].concat(related.map((model: Record) => {
@@ -167,7 +171,7 @@ export default class BelongsToMany extends Relation {
       }
 
       return records
-    }, {} as Records)
+    }, {})
   }
 
   /**

--- a/src/attributes/relations/HasMany.ts
+++ b/src/attributes/relations/HasMany.ts
@@ -14,7 +14,7 @@ export default class HasMany extends Relation {
   related: typeof Model
 
   /**
-   * The foregin key of the related model.
+   * The foreign key of the related model.
    */
   foreignKey: string
 

--- a/src/attributes/relations/HasManyBy.ts
+++ b/src/attributes/relations/HasManyBy.ts
@@ -4,7 +4,6 @@ import { Record, NormalizedData, Collection } from '../../data'
 import Model from '../../model/Model'
 import Query from '../../query/Query'
 import Constraint from '../../query/contracts/RelationshipConstraint'
-import DictionaryOne from '../contracts/DictionaryOne'
 import Relation from './Relation'
 
 export default class HasManyBy extends Relation {
@@ -69,7 +68,7 @@ export default class HasManyBy extends Relation {
 
     this.addConstraintForHasManyBy(relatedQuery, collection)
 
-    const relations = this.mapSingleRelations(relatedQuery.get(), this.ownerKey) as DictionaryOne
+    const relations = this.mapSingleRelations(relatedQuery.get(), this.ownerKey)
 
     collection.forEach((item) => {
       const related = this.getRelatedRecords(relations, item[this.foreignKey])
@@ -92,13 +91,15 @@ export default class HasManyBy extends Relation {
   /**
    * Get related records.
    */
-  getRelatedRecords (records: DictionaryOne, keys: string[]): Collection {
-    return keys.reduce<Collection>((items, id) => {
-      const related = records[id]
+  getRelatedRecords (relations: Map<string, Record>, keys: string[]): Record[] {
+    const records: Record[] = []
 
-      related && items.push(related)
+    relations.forEach((record, id) => {
+      if (keys.indexOf(id) !== -1) {
+        records.push(record)
+      }
+    })
 
-      return items
-    }, [])
+    return records
   }
 }

--- a/src/attributes/relations/HasManyBy.ts
+++ b/src/attributes/relations/HasManyBy.ts
@@ -14,7 +14,7 @@ export default class HasManyBy extends Relation {
   parent: typeof Model
 
   /**
-   * The foregin key of the model.
+   * The foreign key of the model.
    */
   foreignKey: string
 

--- a/src/attributes/relations/HasManyThrough.ts
+++ b/src/attributes/relations/HasManyThrough.ts
@@ -124,7 +124,7 @@ export default class HasManyThrough extends Relation {
    * Create a new indexed map for the through relation.
    */
   mapThroughRelations (throughs: Collection, relatedQuery: Query): Records {
-    const relateds = this.mapManyRelations(relatedQuery.get(), this.secondKey)
+    const relations = this.mapManyRelations(relatedQuery.get(), this.secondKey)
 
     return throughs.reduce<Record>((records, record) => {
       const id = record[this.firstKey]
@@ -133,7 +133,7 @@ export default class HasManyThrough extends Relation {
         records[id] = []
       }
 
-      const related = relateds[record[this.secondLocalKey]] as Record | undefined
+      const related = relations.get(record[this.secondLocalKey])
 
       if (related === undefined) {
         return records

--- a/src/attributes/relations/HasOne.ts
+++ b/src/attributes/relations/HasOne.ts
@@ -14,7 +14,7 @@ export default class HasOne extends Relation {
   related: typeof Model
 
   /**
-   * The foregin key of the related model.
+   * The foreign key of the related model.
    */
   foreignKey: string
 

--- a/src/attributes/relations/MorphMany.ts
+++ b/src/attributes/relations/MorphMany.ts
@@ -20,7 +20,7 @@ export default class MorphMany extends Relation {
   id: string
 
   /**
-   * The field name fthat contains type of the parent model.
+   * The field name that contains type of the parent model.
    */
   type: string
 
@@ -80,7 +80,7 @@ export default class MorphMany extends Relation {
     const relations = this.mapManyRelations(relatedQuery.get(), this.id)
 
     collection.forEach((item) => {
-      const related = relations[item[this.localKey]]
+      const related = relations.get(item[this.localKey])
 
       item[name] = related || []
     })

--- a/src/attributes/relations/MorphOne.ts
+++ b/src/attributes/relations/MorphOne.ts
@@ -20,7 +20,7 @@ export default class MorphOne extends Relation {
   id: string
 
   /**
-   * The field name fthat contains type of the parent model.
+   * The field name that contains type of the parent model.
    */
   type: string
 

--- a/src/attributes/relations/MorphOne.ts
+++ b/src/attributes/relations/MorphOne.ts
@@ -76,7 +76,7 @@ export default class MorphOne extends Relation {
     const relations = this.mapSingleRelations(relatedQuery.get(), this.id)
 
     collection.forEach((item) => {
-      const related = relations[item[this.localKey]]
+      const related = relations.get(item[this.localKey])
 
       item[name] = related || null
     })

--- a/src/attributes/relations/MorphTo.ts
+++ b/src/attributes/relations/MorphTo.ts
@@ -15,7 +15,7 @@ export default class MorphTo extends Relation {
   id: string
 
   /**
-   * The field name fthat contains type of the parent model.
+   * The field name that contains type of the parent model.
    */
   type: string
 

--- a/src/attributes/relations/MorphTo.ts
+++ b/src/attributes/relations/MorphTo.ts
@@ -64,18 +64,18 @@ export default class MorphTo extends Relation {
   load (query: Query, collection: Collection, name: string, constraints: Constraint[]): void {
     const types = this.getTypes(collection)
 
-    const relateds = types.reduce<NormalizedData>((relateds, type) => {
+    const relations = types.reduce((related, type) => {
       const relatedQuery = this.getRelation(query, type, constraints)
 
-      relateds[type] = this.mapSingleRelations(relatedQuery.get(), '$id')
+      related[type] = this.mapSingleRelations(relatedQuery.get(), '$id')
 
-      return relateds
-    }, {} as NormalizedData)
+      return related
+    }, {})
 
     collection.forEach((item) => {
       const id = item[this.id]
       const type = item[this.type]
-      const related = relateds[type][id]
+      const related = relations[type].get(String(id))
 
       item[name] = related || null
     })

--- a/src/attributes/relations/MorphToMany.ts
+++ b/src/attributes/relations/MorphToMany.ts
@@ -21,7 +21,7 @@ export default class MorphToMany extends Relation {
   pivot: typeof Model
 
   /**
-   * The field name that conatins id of the related model.
+   * The field name that contains id of the related model.
    */
   relatedId: string
 
@@ -31,7 +31,7 @@ export default class MorphToMany extends Relation {
   id: string
 
   /**
-   * The field name fthat contains type of the parent model.
+   * The field name that contains type of the parent model.
    */
   type: string
 
@@ -146,16 +146,24 @@ export default class MorphToMany extends Relation {
    * Create a new indexed map for the pivot relation.
    */
   mapPivotRelations (pivots: Collection, relatedQuery: Query): Records {
-    const relateds = this.mapManyRelations(relatedQuery.get(), this.relatedKey)
+    const relations = this.mapManyRelations(relatedQuery.get(), this.relatedKey)
 
-    return pivots.reduce((records, record) => {
+    if (relatedQuery.orders.length) {
+      return this.mapRelationsByOrders(pivots, relations, this.id, this.relatedId)
+    }
+
+    return pivots.reduce<Record>((records, record) => {
       const id = record[this.id]
 
       if (!records[id]) {
         records[id] = []
       }
 
-      const related = relateds[record[this.relatedId]]
+      const related = relations.get(record[this.relatedId])
+
+      if (related === undefined || related.length === 0) {
+        return records
+      }
 
       records[id] = records[id].concat(related.map((model: Record) => {
         model[this.pivotKey] = record
@@ -163,7 +171,7 @@ export default class MorphToMany extends Relation {
       }))
 
       return records
-    }, {} as Records)
+    }, {})
   }
 
   /**

--- a/src/attributes/relations/MorphToMany.ts
+++ b/src/attributes/relations/MorphToMany.ts
@@ -161,6 +161,7 @@ export default class MorphToMany extends Relation {
 
       const related = relations.get(record[this.relatedId])
 
+      /* istanbul ignore if */
       if (related === undefined || related.length === 0) {
         return records
       }

--- a/src/attributes/relations/MorphedByMany.ts
+++ b/src/attributes/relations/MorphedByMany.ts
@@ -21,7 +21,7 @@ export default class MorphedByMany extends Relation {
   pivot: typeof Model
 
   /**
-   * The field name that conatins id of the related model.
+   * The field name that contains id of the related model.
    */
   relatedId: string
 
@@ -31,7 +31,7 @@ export default class MorphedByMany extends Relation {
   id: string
 
   /**
-   * The field name fthat contains type of the parent model.
+   * The field name that contains type of the parent model.
    */
   type: string
 
@@ -147,16 +147,24 @@ export default class MorphedByMany extends Relation {
    * Create a new indexed map for the pivot relation.
    */
   mapPivotRelations (pivots: Collection, relatedQuery: Query): Records {
-    const relateds = this.mapManyRelations(relatedQuery.get(), this.relatedKey)
+    const relations = this.mapManyRelations(relatedQuery.get(), this.relatedKey)
 
-    return pivots.reduce((records, record) => {
+    if (relatedQuery.orders.length) {
+      return this.mapRelationsByOrders(pivots, relations, this.relatedId, this.id)
+    }
+
+    return pivots.reduce<Record>((records, record) => {
       const id = record[this.relatedId]
 
       if (!records[id]) {
         records[id] = []
       }
 
-      const related = relateds[record[this.id]]
+      const related = relations.get(record[this.id])
+
+      if (related === undefined || related.length === 0) {
+        return records
+      }
 
       records[id] = records[id].concat(related.map((model: Record) => {
         model[this.pivotKey] = record
@@ -164,7 +172,7 @@ export default class MorphedByMany extends Relation {
       }))
 
       return records
-    }, {} as Records)
+    }, {})
   }
 
   /**

--- a/src/attributes/relations/MorphedByMany.ts
+++ b/src/attributes/relations/MorphedByMany.ts
@@ -162,6 +162,7 @@ export default class MorphedByMany extends Relation {
 
       const related = relations.get(record[this.id])
 
+      /* istanbul ignore if */
       if (related === undefined || related.length === 0) {
         return records
       }

--- a/src/attributes/relations/Relation.ts
+++ b/src/attributes/relations/Relation.ts
@@ -57,14 +57,18 @@ export default abstract class Relation extends Attribute {
   /**
    * Create a new indexed map for the single relation by specified key.
    */
-  mapSingleRelations (collection: Record[], key: string): Records {
-    return collection.reduce((records, record) => {
+  mapSingleRelations (collection: Record[], key: string): Map<string, Record> {
+    const relations = new Map<string, Record>()
+
+    collection.forEach((record) => {
       const id = record[key]
 
-      records[id] = record
+      if (!relations.get(id)) {
+        relations.set(id, record)
+      }
+    })
 
-      return records
-    }, {} as Records)
+    return relations
   }
 
   /**

--- a/src/attributes/relations/Relation.ts
+++ b/src/attributes/relations/Relation.ts
@@ -63,9 +63,7 @@ export default abstract class Relation extends Attribute {
     collection.forEach((record) => {
       const id = record[key]
 
-      if (!relations.get(id)) {
-        relations.set(id, record)
-      }
+      !relations.get(id) && relations.set(id, record)
     })
 
     return relations

--- a/src/attributes/relations/Relation.ts
+++ b/src/attributes/relations/Relation.ts
@@ -70,18 +70,44 @@ export default abstract class Relation extends Attribute {
   /**
    * Create a new indexed map for the many relation by specified key.
    */
-  mapManyRelations (collection: Record[], key: string): Records {
-    return collection.reduce((records, record) => {
+  mapManyRelations (collection: Record[], key: string): Map<string, Record> {
+    const relations = new Map<string, Record>()
+
+    collection.forEach((record) => {
       const id = record[key]
 
-      if (!records[id]) {
-        records[id] = []
+      let ownerKeys = relations.get(id)
+
+      if (!ownerKeys) {
+        ownerKeys = []
+        relations.set(id, ownerKeys)
       }
 
-      records[id].push(record)
+      ownerKeys.push(record)
+    })
 
-      return records
-    }, {} as Records)
+    return relations
+  }
+
+  /**
+   * Create a new indexed map for relations with order constraints.
+   */
+  mapRelationsByOrders (collection: Collection, relations: Map<string, Record>, ownerKey: string, relationKey: string): Records {
+    const records: Records = {}
+
+    relations.forEach((related, id) => {
+      collection.filter(record => record[relationKey] === id).forEach((record) => {
+        const id = record[ownerKey]
+
+        if (!records[id]) {
+          records[id] = []
+        }
+
+        records[id] = records[id].concat(related)
+      })
+    })
+
+    return records
   }
 
   /**

--- a/test/feature/basics/Retrieve.spec.js
+++ b/test/feature/basics/Retrieve.spec.js
@@ -29,7 +29,7 @@ describe('Feature – Retrieve', () => {
     expect(users).toEqual(expected)
   })
 
-  it('can retrieve all records by chaind all method', () => {
+  it('can retrieve all records by chained all method', () => {
     const store = createStore([{ model: User }])
 
     store.dispatch('entities/users/create', {
@@ -108,7 +108,7 @@ describe('Feature – Retrieve', () => {
     expect(users2).toEqual([])
   })
 
-  it('can retrieve a single item by chaind find method', () => {
+  it('can retrieve a single item by chained find method', () => {
     const store = createStore([{ model: User }])
 
     store.dispatch('entities/users/create', {

--- a/test/feature/relations/BelongsToMany_Retrieve.spec.js
+++ b/test/feature/relations/BelongsToMany_Retrieve.spec.js
@@ -323,4 +323,31 @@ describe('Feature – Relations – Belongs To Many – Retrieve', () => {
     expect(users[0].roles.length).toBe(1)
     expect(users[0].roles[0].id).toBe(1)
   })
+
+  it('can apply `orderBy` constraint on nested relations', async () => {
+    createStore([{ model: User }, { model: Role }, { model: RoleUser }])
+
+    await User.create({
+      data: {
+        id: 1,
+        roles: [{ id: 1 }, { id: 3 }, { id: 2 }]
+      }
+    })
+
+    const ascending = User.query()
+      .with('roles', query => { query.orderBy('id', 'asc') })
+      .find(1)
+
+    expect(ascending.roles[0].id).toBe(1)
+    expect(ascending.roles[1].id).toBe(2)
+    expect(ascending.roles[2].id).toBe(3)
+
+    const descending = User.query()
+      .with('roles', query => { query.orderBy('id', 'desc') })
+      .find(1)
+
+    expect(descending.roles[0].id).toBe(3)
+    expect(descending.roles[1].id).toBe(2)
+    expect(descending.roles[2].id).toBe(1)
+  })
 })

--- a/test/feature/relations/HasManyBy.spec.js
+++ b/test/feature/relations/HasManyBy.spec.js
@@ -232,4 +232,50 @@ describe('Features – Relations – Has Many By', () => {
 
     expect(users).toEqual(expected)
   })
+
+  it('can apply `orderBy` constraint on nested relations', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static fields () {
+        return {
+          id: this.attr(null),
+          post_ids: this.attr([]),
+          posts: this.hasManyBy(Post, 'post_ids')
+        }
+      }
+    }
+
+    class Post extends Model {
+      static entity = 'posts'
+
+      static fields () {
+        return {
+          id: this.attr(null)
+        }
+      }
+    }
+
+    createStore([{ model: User }, { model: Post }])
+
+    await User.insert({
+      data: { id: 1, posts: [{ id: 1 }, { id: 3 }, { id: 2 }] }
+    })
+
+    const ascending = User.query()
+      .with('posts', query => { query.orderBy('id', 'asc') })
+      .find(1)
+
+    expect(ascending.posts[0].id).toBe(1)
+    expect(ascending.posts[1].id).toBe(2)
+    expect(ascending.posts[2].id).toBe(3)
+
+    const descending = User.query()
+      .with('posts', query => { query.orderBy('id', 'desc') })
+      .find(1)
+
+    expect(descending.posts[0].id).toBe(3)
+    expect(descending.posts[1].id).toBe(2)
+    expect(descending.posts[2].id).toBe(1)
+  })
 })

--- a/test/unit/support/Utils.spec.ts
+++ b/test/unit/support/Utils.spec.ts
@@ -134,21 +134,21 @@ describe('Unit - Utils', () => {
               {
                 id: 1,
                 deeper: {
-                  id: 2,
-                },
+                  id: 2
+                }
               },
               {
                 id: 2,
                 deeper: {
-                  id: 3,
-                },
+                  id: 3
+                }
               }
             ]
           }
         ]
       }
 
-      const clone = Utils.cloneDeep(data);
+      const clone = Utils.cloneDeep(data)
 
       expect(clone).toStrictEqual(data)
 


### PR DESCRIPTION
### Description 

Resolves #571 it is reported that nested relations do not observe any ordering constraints applied to them.

#### Type of PR:

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Other

#### Breaking changes:

- [x] No
- [ ] Yes

### Issue Recap

- Applying `orderBy` constraint on nested relations is ignored and relationships are loaded in the order in which they were inserted.
- In some cases where primary keys are integers, the ordering is unreliable because numeric object keys do not preserve the order in which the dictionary is created.

### Proposed Solution

- Use [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) to generate relation indexes to make sure the ordering is preserved for numeric keys. 
- Only iterate over recursive relations if the relation query contains any order constraints to avoid expensive iterations for relations without.