### PR TITLE
fix(query): `findIn` should resolve child relations

### DIFF
--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -267,7 +267,7 @@ export default class Query<T extends Model = Model> {
    * Get the record of the given array of ids.
    */
   findIn (idList: (number | string | (number | string)[])[]): Data.Collection<T> {
-    return idList.reduce<Data.Collection<T>>((collection, id) => {
+    const records = idList.reduce<Data.Collection<T>>((collection, id) => {
       const indexId = Array.isArray(id) ? JSON.stringify(id) : id
 
       const record = this.state.data[indexId]
@@ -280,6 +280,8 @@ export default class Query<T extends Model = Model> {
 
       return collection
     }, [])
+
+    return this.collect(records)
   }
 
   /**
@@ -343,7 +345,7 @@ export default class Query<T extends Model = Model> {
    * Add a or where clause to the query.
    */
   orWhere (field: any, value?: any): this {
-    // Cacncel id filter usage, since "or" needs full scan.
+    // Cancel id filter usage, since "or" needs full scan.
     this.cancelIdFilter = true
 
     this.wheres.push({ field, value, boolean: 'or' })
@@ -637,7 +639,7 @@ export default class Query<T extends Model = Model> {
   }
 
   /**
-   * Limit the given records by the lmilt and offset.
+   * Limit the given records by the limit and offset.
    */
   filterLimit (records: Data.Collection<T>): Data.Collection<T> {
     return Filter.limit<T>(this, records)


### PR DESCRIPTION
### Description

This PR fixes the `findIn` method not resolving child relations like its counterpart `find` does. Resolves #588.

#### Type of PR:

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Other

#### Breaking changes:

- [x] No
- [ ] Yes

### Details

Consider the following:

```js
User.insert({
  id: 1,
  posts: [{ id: 1 }, { id: 2 }]
})

User.query().with('posts').findIn([1, 2])
```

Current behavior:

```js
[
  {
    $id: 1,
    id: 1,
    posts: []
  }
]
```

Behavior changes in this PR:

```js
[
  {
    $id: 1,
    id: 1,
    posts: [
      { $id: 1, id: 1 },
      { $id: 2, id: 2 }
    ]
  }
]
```