### PR TITLE
fix: use `isArray` util function to check the type of the array

### DIFF
--- a/src/attributes/relations/BelongsToMany.ts
+++ b/src/attributes/relations/BelongsToMany.ts
@@ -178,7 +178,7 @@ export default class BelongsToMany extends Relation {
    * Create pivot records for the given records if needed.
    */
   createPivots (parent: typeof Model, data: NormalizedData, key: string): NormalizedData {
-    if (this.pivot.primaryKey instanceof Array === false) return data
+    if (!Utils.isArray(this.pivot.primaryKey)) return data
 
     Utils.forOwn(data[parent.entity], (record) => {
       const related = record[key]

--- a/src/attributes/relations/MorphToMany.ts
+++ b/src/attributes/relations/MorphToMany.ts
@@ -187,7 +187,7 @@ export default class MorphToMany extends Relation {
 
       const relateds = (record[key] || []).filter((relatedId: any) => !relatedIds.includes(relatedId))
 
-      if (!Array.isArray(relateds) || relateds.length === 0) {
+      if (!Utils.isArray(relateds) || relateds.length === 0) {
         return
       }
 

--- a/src/attributes/relations/MorphedByMany.ts
+++ b/src/attributes/relations/MorphedByMany.ts
@@ -183,7 +183,7 @@ export default class MorphedByMany extends Relation {
     Utils.forOwn(data[parent.entity], (record) => {
       const related = record[key]
 
-      if (!Array.isArray(related)) {
+      if (!Utils.isArray(related)) {
         return
       }
 

--- a/src/attributes/relations/Relation.ts
+++ b/src/attributes/relations/Relation.ts
@@ -1,4 +1,5 @@
 import { Schema as NormalizrSchema } from 'normalizr'
+import { isArray } from '../../support/Utils'
 import Schema from '../../schema/Schema'
 import { Record, Records, NormalizedData, Collection } from '../../data'
 import Model from '../../model/Model'
@@ -116,7 +117,7 @@ export default abstract class Relation extends Attribute {
    * Check if the given record is a single relation, which is an object.
    */
   isOneRelation (record: any): boolean {
-    if (!Array.isArray(record) && record !== null && typeof record === 'object') {
+    if (!isArray(record) && record !== null && typeof record === 'object') {
       return true
     }
 
@@ -128,7 +129,7 @@ export default abstract class Relation extends Attribute {
    * of object.
    */
   isManyRelation (records: any): boolean {
-    if (!Array.isArray(records)) {
+    if (!isArray(records)) {
       return false
     }
 

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -430,7 +430,7 @@ export default class Model {
    * in the composite key.
    */
   static isPrimaryKey (key: string): boolean {
-    if (!Array.isArray(this.primaryKey)) {
+    if (!Utils.isArray(this.primaryKey)) {
       return this.primaryKey === key
     }
 
@@ -441,7 +441,7 @@ export default class Model {
    * Check if the primary key is a composite key.
    */
   static isCompositePrimaryKey (): boolean {
-    return Array.isArray(this.primaryKey)
+    return Utils.isArray(this.primaryKey)
   }
 
   /**
@@ -507,7 +507,7 @@ export default class Model {
       return null
     }
 
-    if (Array.isArray(id)) {
+    if (Utils.isArray(id)) {
       return JSON.stringify(id)
     }
 
@@ -745,7 +745,7 @@ export default class Model {
    * Update records.
    */
   async $update (payload: Payloads.Update): Promise<Collections> {
-    if (Array.isArray(payload)) {
+    if (Utils.isArray(payload)) {
       return this.$dispatch('update', payload)
     }
 
@@ -797,7 +797,7 @@ export default class Model {
   async $delete (): Promise<Item<this>> {
     const primaryKey = this.$primaryKey()
 
-    if (!Array.isArray(primaryKey)) {
+    if (!Utils.isArray(primaryKey)) {
       return this.$dispatch('delete', this[primaryKey])
     }
 
@@ -844,7 +844,7 @@ export default class Model {
    */
   $generatePrimaryId (): this {
     const key = this.$self().primaryKey
-    const keys = Array.isArray(key) ? key : [key]
+    const keys = Utils.isArray(key) ? key : [key]
 
     keys.forEach((k) => {
       if (this[k] === undefined || this[k] === null) {

--- a/src/model/Serialize.ts
+++ b/src/model/Serialize.ts
@@ -1,3 +1,4 @@
+import { isArray } from '../support/Utils'
 import Record from '../data/Record'
 import Item from '../data/Item'
 import Collection from '../data/Collection'
@@ -57,7 +58,7 @@ function value (v: any): any {
     return null
   }
 
-  if (Array.isArray(v)) {
+  if (isArray(v)) {
     return array(v)
   }
 
@@ -98,7 +99,7 @@ function relation (relation: Item | Collection): Record | Record[] | null {
     return null
   }
 
-  if (Array.isArray(relation)) {
+  if (isArray(relation)) {
     return relation.map(model => model.$toJson())
   }
 
@@ -111,5 +112,5 @@ function relation (relation: Item | Collection): Record | Record[] | null {
 function emptyRelation (relation: Item): null
 function emptyRelation (relation: Collection): []
 function emptyRelation (relation: Item | Collection): [] | null {
-  return Array.isArray(relation) ? [] : null
+  return isArray(relation) ? [] : null
 }

--- a/src/modules/Actions.ts
+++ b/src/modules/Actions.ts
@@ -1,3 +1,4 @@
+import { isArray } from '../support/Utils'
 import Item from '../data/Item'
 import Collection from '../data/Collection'
 import Collections from '../data/Collections'
@@ -49,7 +50,7 @@ async function update (context: ActionContext, payload: Payloads.Update): Promis
 
   // If the payload is an array, then the payload should be an array of
   // data so let's pass the whole payload as data.
-  if (Array.isArray(payload)) {
+  if (isArray(payload)) {
     return context.dispatch(`${state.$connection}/update`, { entity, data: payload }, { root: true })
   }
 

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -265,7 +265,7 @@ export default class Query<T extends Model = Model> {
    * Get the record of the given array of ids.
    */
   findIn (values: Options.PrimaryKey[]): Data.Collection<T> {
-    if (!Array.isArray(values)) {
+    if (!Utils.isArray(values)) {
       return []
     }
 
@@ -388,7 +388,7 @@ export default class Query<T extends Model = Model> {
    * Fk lookups are always "and" type.
    */
   whereFk (field: string, value: Options.PrimaryKey): this {
-    const values = Array.isArray(value) ? value : [value]
+    const values = Utils.isArray(value) ? value : [value]
 
     // If lookup filed is the primary key. Initialize or get intersection,
     // because boolean and could have a condition such as
@@ -415,7 +415,7 @@ export default class Query<T extends Model = Model> {
    */
   private normalizeIndexId (value: Options.PrimaryKey): string | number {
     if (this.model.isCompositePrimaryKey()) {
-      if (!Array.isArray(value)) {
+      if (!Utils.isArray(value)) {
         throw new Error(
           '[Vuex ORM] Entity `' + this.entity + '` is configured with a composite ' +
           'primary key and expects an array value but instead received: ' + JSON.stringify(value)
@@ -425,7 +425,7 @@ export default class Query<T extends Model = Model> {
       return JSON.stringify(value)
     }
 
-    if (Array.isArray(value)) {
+    if (Utils.isArray(value)) {
       throw new Error(
         '[Vuex ORM] Entity `' + this.entity + '` expects a single value but ' +
         'instead received: ' + JSON.stringify(value)
@@ -447,7 +447,7 @@ export default class Query<T extends Model = Model> {
    * Set id filter for the given where condition.
    */
   private setIdFilter (value: string | number | (string | number)[]): void {
-    const values = Array.isArray(value) ? value : [value]
+    const values = Utils.isArray(value) ? value : [value]
 
     // Initialize or get intersection, because boolean and could have a
     // condition such as `whereIdIn([1,2,3]).whereIdIn([1,2]).get()`.
@@ -829,7 +829,7 @@ export default class Query<T extends Model = Model> {
    */
   update (data: Data.Record | Data.Record[] | UpdateClosure, condition: UpdateCondition, options: Options.PersistOptions): Data.Item<T> | Data.Collection<T> | Data.Collections {
     // If the data is array, simply normalize the data and update them.
-    if (Array.isArray(data)) {
+    if (Utils.isArray(data)) {
       return this.persist('update', data, options)
     }
 
@@ -867,7 +867,7 @@ export default class Query<T extends Model = Model> {
     // Now since the condition is either String or Number, let's check if the
     // model's primary key is not a composite key. If yes, we can't set the
     // condition as ID value for the record so throw an error and abort.
-    if (this.model.isCompositePrimaryKey() && !Array.isArray(condition)) {
+    if (this.model.isCompositePrimaryKey() && !Utils.isArray(condition)) {
       throw new Error(
         '[Vuex ORM] You can\'t specify `where` value as `string` or `number` ' +
         'when you have a composite key defined in your model. Please include ' +

--- a/src/query/filters/WhereFilter.ts
+++ b/src/query/filters/WhereFilter.ts
@@ -62,7 +62,7 @@ export default class WhereFilter {
       }
 
       // Check if field value is in given where Array.
-      if (Array.isArray(where.value)) {
+      if (Utils.isArray(where.value)) {
         return where.value.indexOf(record[where.field]) !== -1
       }
 

--- a/src/query/loaders/Loader.ts
+++ b/src/query/loaders/Loader.ts
@@ -1,3 +1,4 @@
+import { isArray } from '../../support/Utils'
 import Collection from '../../data/Collection'
 import Relation from '../../attributes/relations/Relation'
 import Constraint from '../contracts/RelationshipConstraint'
@@ -16,7 +17,7 @@ export default class Loader {
     }
 
     // If we passed an array, we dispatch the bits to with queries.
-    if (Array.isArray(name)) {
+    if (isArray(name)) {
       name.forEach(relationName => this.with(query, relationName, constraint))
 
       return

--- a/src/query/processors/Normalizer.ts
+++ b/src/query/processors/Normalizer.ts
@@ -17,7 +17,7 @@ export default class Normalizer {
 
     const entity = query.database.schemas[query.model.entity]
 
-    const schema = Array.isArray(data) ? [entity] : entity
+    const schema = Utils.isArray(data) ? [entity] : entity
 
     return normalize(data, schema).entities as NormalizedData
   }

--- a/src/query/rollcallers/Rollcaller.ts
+++ b/src/query/rollcallers/Rollcaller.ts
@@ -1,3 +1,4 @@
+import { isArray } from '../../support/Utils'
 import Item from '../../data/Item'
 import Collection from '../../data/Collection'
 import Model from '../../model/Model'
@@ -127,7 +128,7 @@ export default class Rollcaller {
    * Get count of the relationship.
    */
   private static getRelationshipCount (relation: Collection | Item): number {
-    if (Array.isArray(relation)) {
+    if (isArray(relation)) {
       return relation.length
     }
 

--- a/src/schema/IdAttribute.ts
+++ b/src/schema/IdAttribute.ts
@@ -1,4 +1,5 @@
 import { schema } from 'normalizr'
+import { isArray } from '../support/Utils'
 import Uid from '../support/Uid'
 import Record from '../data/Record'
 import UidAttribute from '../attributes/types/Uid'
@@ -24,7 +25,7 @@ export default class IdAttribute {
    * UID for it.
    */
   private static generateIds (record: Record, model: typeof Model): void {
-    const keys = Array.isArray(model.primaryKey) ? model.primaryKey : [model.primaryKey]
+    const keys = isArray(model.primaryKey) ? model.primaryKey : [model.primaryKey]
 
     keys.forEach((k) => {
       if (record[k] !== undefined && record[k] !== null) {

--- a/src/support/Utils.ts
+++ b/src/support/Utils.ts
@@ -13,11 +13,18 @@ interface SortableArray<T> {
 }
 
 /**
+ * Check if the given value is the type of array.
+ */
+export function isArray (value: any): value is any[] {
+  return Array.isArray(value)
+}
+
+/**
  * Gets the size of collection by returning its length for array-like values
  * or the number of own enumerable string keyed properties for objects.
  */
 export function size (collection: any[] | object): number {
-  return Array.isArray(collection) ? collection.length : Object.keys(collection).length
+  return isArray(collection) ? collection.length : Object.keys(collection).length
 }
 
 /**
@@ -216,7 +223,7 @@ export function cloneDeep <T extends object> (target: T): T {
     return target
   }
 
-  if (target instanceof Array) {
+  if (isArray(target)) {
     const cp = [] as any[];
 
     (target as any[]).forEach((v) => cp.push(v))
@@ -236,6 +243,7 @@ export function cloneDeep <T extends object> (target: T): T {
 }
 
 export default {
+  isArray,
   size,
   isEmpty,
   forOwn,


### PR DESCRIPTION
When checking a value is a type of array, using `foo instanceof Array` was causing false negative in Nuxt server side env. It's fixed by using `Array.isArray()` instead.

This PR adds `isArray` utility function, and replaces all `Array.isArray()` and `foo instanceof Array` condition checks.

#### Type of PR:

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Other

#### Breaking changes:

- [x] No
- [ ] Yes