### PR TITLE
refactor(query): remove double deep copy

### DIFF
--- a/src/query/processors/Normalizer.ts
+++ b/src/query/processors/Normalizer.ts
@@ -13,12 +13,10 @@ export default class Normalizer {
       return {}
     }
 
-    const data = Utils.cloneDeep(record)
-
     const entity = query.database.schemas[query.model.entity]
 
-    const schema = Utils.isArray(data) ? [entity] : entity
+    const schema = Utils.isArray(record) ? [entity] : entity
 
-    return normalize(data, schema).entities as NormalizedData
+    return normalize(record, schema).entities as NormalizedData
   }
 }


### PR DESCRIPTION
This PR removes `deepCopy` inside normalizer. Since deep copy is done at `persist` method [at here](https://github.com/vuex-orm/vuex-orm/blob/3a2f77000b21df83d2925030445f9a350b835091/src/query/Query.ts#L1040), I think it's unnecessary to do it here.

@cuebit Could you check if this looks ok?

#### Type of PR:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes