### PR TITLE
fix: wildcard relations should observe constraints (#603)

### DIFF
--- a/docs/guide/data/retrieving.md
+++ b/docs/guide/data/retrieving.md
@@ -168,7 +168,7 @@ You may pass a closure to the 2nd argument when you need more powerful constrain
 
 ```js
 // Get users with age higher than 20.
-const user = User.query().where('age', value => value > 20).get()
+const user = User.query().where('age', (value) => value > 20).get()
 ```
 
 Or, you may pass a closure to the 1st argument to get full control of the condition. The argument is the data itself.
@@ -418,7 +418,7 @@ const user = User.query()
 
 ### Load All Relations
 
-You can load all relations using the `withAll` method.
+You can load all relations on a model using the `withAll` method.
 
 ```js
 const user = User.query().withAll().first()
@@ -449,6 +449,14 @@ const user = User.query().withAll().first()
     ]
   }
 */
+```
+
+Constraints may also be added for more granular control.
+
+```js
+const user = User.query().withAll((query) => {
+  query.has('comments')
+}).first()
 ```
 
 To fetch all sub relations of a relation using the dot syntax, use `*`.
@@ -533,7 +541,7 @@ const user = User.query().with('posts.comments', (query) => {
 }).get()
 ```
 
-Similarly, you may add constraints to wilcard relations. For example, `posts` may have `comments` and `tags`, all of which will be ordered by the `created_at` field.
+Similarly, you may add constraints to wildcard relations. For example, `posts` may have `comments` and `tags`, all of which will be ordered by the `created_at` field.
 
 ```js
 const user = User.query().with('posts.*', (query) => {

--- a/docs/guide/data/retrieving.md
+++ b/docs/guide/data/retrieving.md
@@ -533,6 +533,15 @@ const user = User.query().with('posts.comments', (query) => {
 }).get()
 ```
 
+Similarly, you may add constraints to wilcard relations. For example, `posts` may have `comments` and `tags`, all of which will be ordered by the `created_at` field.
+
+```js
+const user = User.query().with('posts.*', (query) => {
+  // This constraint will be applied to all relations belonging to `posts`
+  query.orderBy('created_at', 'desc')
+}).get()
+```
+
 If you need to add constraints to each relation, you could always nest constraints. This is the most flexible way of defining constraints to the relationships.
 
 ```js

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -518,8 +518,8 @@ export default class Query<T extends Model = Model> {
   /**
    * Query all relations.
    */
-  withAll (): this {
-    Loader.withAll(this)
+  withAll (constraint: Contracts.RelationshipConstraint | null = null): this {
+    Loader.withAll(this, constraint)
 
     return this
   }

--- a/src/query/loaders/Loader.ts
+++ b/src/query/loaders/Loader.ts
@@ -11,7 +11,7 @@ export default class Loader {
   static with (query: Query, name: string | string[], constraint: Constraint | null): void {
     // If the name of the relation is `*`, we'll load all relationships.
     if (name === '*') {
-      this.withAll(query)
+      this.withAll(query, constraint)
 
       return
     }
@@ -30,7 +30,7 @@ export default class Loader {
   /**
    * Set all relationships to be eager loaded with the query.
    */
-  static withAll (query: Query, constraint: Constraint = () => null): void {
+  static withAll (query: Query, constraint: Constraint | null): void {
     const fields = query.model.getFields()
 
     for (const field in fields) {

--- a/test/feature/relations/Retrieve_With_NestedConstraints.spec.ts
+++ b/test/feature/relations/Retrieve_With_NestedConstraints.spec.ts
@@ -3,68 +3,70 @@ import { createStore } from 'test/support/Helpers'
 import Model from '@/model/Model'
 
 describe('Feature – Relations – With – Nested Constraints', () => {
-  it('can apply `with` constraints to nested relationships', async () => {
-    class User extends Model {
-      static entity = 'users'
+  class User extends Model {
+    static entity = 'users'
 
-      // @Attribute
-      id!: number
+    // @Attribute
+    id!: number
 
-      // @HasMany(Post, 'user_id')
-      posts!: Post[]
+    // @HasMany(Post, 'user_id')
+    posts!: Post[]
 
-      static fields () {
-        return {
-          id: this.attr(null),
-          posts: this.hasMany(Post, 'user_id')
-        }
+    static fields () {
+      return {
+        id: this.attr(null),
+        posts: this.hasMany(Post, 'user_id')
       }
     }
+  }
 
-    class Post extends Model {
-      static entity = 'posts'
+  class Post extends Model {
+    static entity = 'posts'
 
-      // @Attribute
-      id!: number
+    // @Attribute
+    id!: number
 
-      // @Attribute
-      user_id!: number
+    // @Attribute
+    user_id!: number
 
-      // @HasMany(Comment, 'post_id')
-      comments!: Comment[]
+    // @HasMany(Comment, 'post_id')
+    comments!: Comment[]
 
-      static fields () {
-        return {
-          id: this.attr(null),
-          user_id: this.attr(null),
-          comments: this.hasMany(Comment, 'post_id')
-        }
+    static fields () {
+      return {
+        id: this.attr(null),
+        user_id: this.attr(null),
+        comments: this.hasMany(Comment, 'post_id')
       }
     }
+  }
 
-    class Comment extends Model {
-      static entity = 'comments'
+  class Comment extends Model {
+    static entity = 'comments'
 
-      // @Attribute
-      id!: number
+    // @Attribute
+    id!: number
 
-      // @Attribute('')
-      title!: string
+    // @Attribute('')
+    title!: string
 
-      // @Attribute
-      user_id!: number
+    // @Attribute
+    user_id!: number
 
-      static fields () {
-        return {
-          id: this.attr(null),
-          title: this.attr(''),
-          post_id: this.attr(null)
-        }
+    static fields () {
+      return {
+        id: this.attr(null),
+        title: this.attr(''),
+        post_id: this.attr(null)
       }
     }
+  }
 
+  beforeEach(() => {
     createStore([{ model: User }, { model: Post }, { model: Comment }])
+  })
 
+  it('can apply `with` constraints to nested relations', async () => {
     await User.create({ data: { id: 1 } })
 
     await Post.create({ data: { id: 1, user_id: 1 } })
@@ -84,5 +86,55 @@ describe('Feature – Relations – With – Nested Constraints', () => {
     expect(user.posts.length).toBe(1)
     expect(user.posts[0].comments.length).toBe(2)
     expect(user.posts[0].comments[0].title).toBe('Title01')
+  })
+
+  it('can apply `withAll` constraints to nested relations', async () => {
+    await User.create({ data: { id: 1 } })
+
+    await Post.create({ data: [{ id: 1, user_id: 1 }, { id: 2, user_id: 1 }] })
+
+    await Comment.create({
+      data: [
+        { id: 1, post_id: 1, title: 'Title01' },
+        { id: 2, post_id: 1, title: 'Title01' },
+        { id: 3, post_id: 1, title: 'Title02' }
+      ]
+    })
+
+    const user = User.query().withAll((query) => {
+      query.where('id', 2)
+    }).find(1) as User
+
+    expect(user.posts.length).toBe(1)
+    expect(user.posts[0].comments.length).toEqual(0)
+    expect(user.posts[0].id).toBe(2)
+  })
+
+  it('can apply constraints to multiple sub relations', async () => {
+    await User.create({ data: { id: 1 } })
+
+    await Post.create({ data: { id: 1, user_id: 1 } })
+
+    await Comment.create({
+      data: [
+        { id: 1, post_id: 1, title: 'Beta' },
+        { id: 2, post_id: 1, title: 'Cyprus' },
+        { id: 3, post_id: 1, title: 'Alpha' }
+      ]
+    })
+
+    const user = User.query().with('posts.*', (query) => {
+      query.orderBy('title')
+    }).find(1) as User
+
+    const expected = [
+      { '$id': '3', id: 3, title: 'Alpha', post_id: 1 },
+      { '$id': '1', id: 1, title: 'Beta', post_id: 1 },
+      { '$id': '2', id: 2, title: 'Cyprus', post_id: 1 }
+    ]
+
+    expect(user.posts.length).toBe(1)
+    expect(user.posts[0].comments.length).toBe(3)
+    expect(user.posts[0].comments).toEqual(expected)
   })
 })


### PR DESCRIPTION
This PR resolves #603.

#### Type of PR:

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes

### Details

Wildcard relation loading invokes `withAll` immediately but does not observe any constraint(s) that may exist. This PR passes on any constraint(s) to the invokable and resolves as a **bugfix**.

Moreover, this means the `withAll` query method can observe constraints. Since this was not previously possible, it can be classified as a new **feature**.

Furthermore, the **documentation** has been updated to include an example of how constraints can be applied to both `withAll` and wildcard relation queries.