### PR TITLE
Fix Date attribute being incorrectly handled

### DIFF
--- a/src/model/Serialize.ts
+++ b/src/model/Serialize.ts
@@ -61,6 +61,11 @@ function value(v: any): any {
   if (isArray(v)) {
     return array(v)
   }
+  
+  // 'Invalid Date' will also fall here
+  if (v instanceof Date) {
+    return v
+  }
 
   if (typeof v === 'object') {
     return object(v)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- Please describe a summary of this PR. -->
When checking for fields, if there's a `Date` object it gets handled by the `object` function and it returns an empty object.

This PR handles only the case when the passed value is a `Date`, it doesn't do any checks on whether is a valid date, therefore an `Invalid Date` will also be caught in this condition.

#### Type of PR:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes

### Details

<!-- Please describe the details of the PR. -->

Fixes #624 

I think the handling of `Invalid Date`s should be in the hands of the developer as this is merely a serializer but more checks can be added to handle the invalid dates.